### PR TITLE
[Feature] 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 application-dev.yml
 application-prod.yml
 application-jwt.yml
+application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 }
 
 dependencies {
+    // Http Interface
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    testImplementation 'io.projectreactor:reactor-test'
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -50,6 +54,8 @@ dependencies {
     // Spring Rest Docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    // ARM Native Library Compatibility
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64'
 }
 
 tasks.named('bootBuildImage') {
@@ -82,7 +88,7 @@ asciidoctor {
 
 bootJar {
     dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}/html5") {
+    from("${asciidoctor.outputDir}/html5") {
         into 'src/main/resources/static/docs'
     }
 }

--- a/src/main/java/com/jisungin/JisunginApplication.java
+++ b/src/main/java/com/jisungin/JisunginApplication.java
@@ -2,8 +2,10 @@ package com.jisungin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class JisunginApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/jisungin/api/oauth/OauthController.java
+++ b/src/main/java/com/jisungin/api/oauth/OauthController.java
@@ -1,0 +1,38 @@
+package com.jisungin.api.oauth;
+
+import com.jisungin.api.ApiResponse;
+import com.jisungin.application.oauth.OauthService;
+import com.jisungin.domain.oauth.OauthType;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/oauth")
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @SneakyThrows
+    @GetMapping("/{oauthType}")
+    public ApiResponse<Void> redirectAuthRequestUrl(
+            @PathVariable OauthType oauthType,
+            HttpServletResponse response
+    ) {
+        String redirectUrl = oauthService.getAuthCodeRequestUrl(oauthType);
+        response.sendRedirect(redirectUrl);
+        return ApiResponse.ok(null);
+    }
+
+    @GetMapping("/login/{oauthType}")
+    public ApiResponse<Long> login(
+            @PathVariable OauthType oauthType,
+            @RequestParam("code") String code
+    ) {
+        Long login = oauthService.login(oauthType, code);
+        return ApiResponse.ok(login);
+    }
+
+}

--- a/src/main/java/com/jisungin/api/oauth/OauthTypeConverter.java
+++ b/src/main/java/com/jisungin/api/oauth/OauthTypeConverter.java
@@ -1,0 +1,13 @@
+package com.jisungin.api.oauth;
+
+import com.jisungin.domain.oauth.OauthType;
+import org.springframework.core.convert.converter.Converter;
+
+public class OauthTypeConverter implements Converter<String, OauthType> {
+
+    @Override
+    public OauthType convert(String source) {
+        return OauthType.fromName(source);
+    }
+
+}

--- a/src/main/java/com/jisungin/application/oauth/OauthService.java
+++ b/src/main/java/com/jisungin/application/oauth/OauthService.java
@@ -7,9 +7,11 @@ import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OauthService {
 
     private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
@@ -20,6 +22,7 @@ public class OauthService {
         return authCodeRequestUrlProviderComposite.provide(oauthType);
     }
 
+    @Transactional
     public Long login(OauthType oauthType, String authCode) {
         User user = userClientComposite.fetch(oauthType, authCode);
         User savedUser = userRepository.findByOauthId(user.getOauthId())

--- a/src/main/java/com/jisungin/application/oauth/OauthService.java
+++ b/src/main/java/com/jisungin/application/oauth/OauthService.java
@@ -1,0 +1,31 @@
+package com.jisungin.application.oauth;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.oauth.authcode.AuthCodeRequestUrlProviderComposite;
+import com.jisungin.domain.oauth.client.UserClientComposite;
+import com.jisungin.domain.user.User;
+import com.jisungin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
+    private final UserClientComposite userClientComposite;
+    private final UserRepository userRepository;
+
+    public String getAuthCodeRequestUrl(OauthType oauthType) {
+        return authCodeRequestUrlProviderComposite.provide(oauthType);
+    }
+
+    public Long login(OauthType oauthType, String authCode) {
+        User user = userClientComposite.fetch(oauthType, authCode);
+        User savedUser = userRepository.findByOauthId(user.getOauthId())
+                .orElseGet(() -> userRepository.save(user));
+        // TODO. 추후에 다른 식별자로 구현할 예정
+        return savedUser.getId();
+    }
+
+}

--- a/src/main/java/com/jisungin/config/WebConfig.java
+++ b/src/main/java/com/jisungin/config/WebConfig.java
@@ -1,0 +1,33 @@
+package com.jisungin.config;
+
+import com.jisungin.api.oauth.OauthTypeConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.DELETE.name()
+                )
+                .allowCredentials(true)
+                .exposedHeaders("*");
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new OauthTypeConverter());
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/OauthId.java
+++ b/src/main/java/com/jisungin/domain/oauth/OauthId.java
@@ -1,0 +1,28 @@
+package com.jisungin.domain.oauth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class OauthId {
+
+    @Column(nullable = false, name = "oauth_id")
+    private String oauthId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "oauth_type")
+    private OauthType oauthType;
+
+    @Builder
+    public OauthId(String oauthId, OauthType oauthType) {
+        this.oauthId = oauthId;
+        this.oauthType = oauthType;
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/OauthType.java
+++ b/src/main/java/com/jisungin/domain/oauth/OauthType.java
@@ -1,0 +1,13 @@
+package com.jisungin.domain.oauth;
+
+import java.util.Locale;
+
+public enum OauthType {
+
+    KAKAO;
+
+    public static OauthType fromName(String name) {
+        return OauthType.valueOf(name.toUpperCase(Locale.ENGLISH));
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/authcode/AuthCodeRequestUrlProvider.java
+++ b/src/main/java/com/jisungin/domain/oauth/authcode/AuthCodeRequestUrlProvider.java
@@ -1,0 +1,13 @@
+package com.jisungin.domain.oauth.authcode;
+
+import com.jisungin.domain.oauth.OauthType;
+
+public interface AuthCodeRequestUrlProvider {
+
+    // 인증 서버의 타입
+    OauthType supportType();
+
+    // 인증 코드 요청 주소
+    String provide();
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/authcode/AuthCodeRequestUrlProviderComposite.java
+++ b/src/main/java/com/jisungin/domain/oauth/authcode/AuthCodeRequestUrlProviderComposite.java
@@ -1,0 +1,38 @@
+package com.jisungin.domain.oauth.authcode;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.jisungin.exception.ErrorCode.OAUTH_TYPE_NOT_FOUND;
+
+@Component
+public class AuthCodeRequestUrlProviderComposite {
+
+    private final Map<OauthType, AuthCodeRequestUrlProvider> mapping;
+
+    public AuthCodeRequestUrlProviderComposite(Set<AuthCodeRequestUrlProvider> providers) {
+        mapping = providers.stream()
+                .collect(Collectors.toMap(
+                        AuthCodeRequestUrlProvider::supportType,
+                        Function.identity()
+                ));
+    }
+
+    public String provide(OauthType oauthType) {
+        return getProvider(oauthType).provide();
+    }
+
+    public AuthCodeRequestUrlProvider getProvider(OauthType oauthType) {
+        return Optional.ofNullable(mapping.get(oauthType))
+                // TODO. 추후에 OAuth 예외 처리로 수정할 것
+                .orElseThrow(() -> new BusinessException(OAUTH_TYPE_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/client/UserClient.java
+++ b/src/main/java/com/jisungin/domain/oauth/client/UserClient.java
@@ -1,0 +1,12 @@
+package com.jisungin.domain.oauth.client;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.user.User;
+
+public interface UserClient {
+
+    OauthType supportType();
+
+    User fetch(String authCode);
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/client/UserClientComposite.java
+++ b/src/main/java/com/jisungin/domain/oauth/client/UserClientComposite.java
@@ -1,0 +1,38 @@
+package com.jisungin.domain.oauth.client;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.user.User;
+import com.jisungin.exception.BusinessException;
+import com.jisungin.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class UserClientComposite {
+
+    private final Map<OauthType, UserClient> mapping;
+
+    public UserClientComposite(Set<UserClient> clients) {
+        this.mapping = clients.stream()
+                .collect(Collectors.toMap(
+                        UserClient::supportType,
+                        Function.identity()
+                ));
+    }
+
+    public User fetch(OauthType oauthType, String authCode) {
+        return getClient(oauthType).fetch(authCode);
+    }
+
+    private UserClient getClient(OauthType oauthType) {
+        return Optional.ofNullable(mapping.get(oauthType))
+                // TODO. 추후에 OAuth 예외 처리로 수정할 것
+                .orElseThrow(() -> new BusinessException(ErrorCode.OAUTH_TYPE_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/user/User.java
+++ b/src/main/java/com/jisungin/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.jisungin.domain.user;
 
 import com.jisungin.domain.BaseEntity;
+import com.jisungin.domain.oauth.OauthId;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,7 +10,17 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "oauth_id_unique",
+                        columnNames = {
+                                "oauth_id",
+                                "oauth_type"
+                        }
+                ),
+        }
+)
 @Entity
 public class User extends BaseEntity {
 
@@ -18,16 +29,20 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    @Embedded
+    private OauthId oauthId;
+
     @Column(name = "user_name")
     private String name;
 
-    @Column(name = "user_profile")
-    private String profile;
+    @Column(name = "user_profile_image")
+    private String profileImage;
 
     @Builder
-    private User(String name, String profile) {
+    public User(OauthId oauthId, String name, String profileImage) {
+        this.oauthId = oauthId;
         this.name = name;
-        this.profile = profile;
+        this.profileImage = profileImage;
     }
 
 }

--- a/src/main/java/com/jisungin/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/jisungin/domain/user/repository/UserRepository.java
@@ -1,9 +1,18 @@
 package com.jisungin.domain.user.repository;
 
+import com.jisungin.domain.oauth.OauthId;
 import com.jisungin.domain.user.User;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByName(String userEmail);
+
+    Optional<User> findByOauthId(OauthId oauthId);
+
 }

--- a/src/main/java/com/jisungin/exception/ErrorCode.java
+++ b/src/main/java/com/jisungin/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
 
     USER_NOT_FOUND(400, "사용자를 찾을 수 없습니다."),
     BOOK_NOT_FOUND(400, "책을 찾을 수 없습니다."),
-    PARTICIPATION_CONDITION_ERROR(400, "참가 조건은 1개 이상이어야 합니다.");
+    PARTICIPATION_CONDITION_ERROR(400, "참가 조건은 1개 이상이어야 합니다."),
+    OAUTH_TYPE_NOT_FOUND(404, "지원하지 않은 소셜 로그인입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/jisungin/infra/oauth/authcode/KakaoAuthCodeRequestUrlProvider.java
+++ b/src/main/java/com/jisungin/infra/oauth/authcode/KakaoAuthCodeRequestUrlProvider.java
@@ -1,0 +1,31 @@
+package com.jisungin.infra.oauth.authcode;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.oauth.authcode.AuthCodeRequestUrlProvider;
+import com.jisungin.infra.oauth.kakao.KakaoOauthConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthCodeRequestUrlProvider implements AuthCodeRequestUrlProvider {
+
+    private final KakaoOauthConfig kakaoOauthConfig;
+
+    @Override
+    public OauthType supportType() {
+        return OauthType.KAKAO;
+    }
+
+    @Override
+    public String provide() {
+        return UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("client_id", kakaoOauthConfig.clientId())
+                .queryParam("redirect_uri", kakaoOauthConfig.redirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", String.join(",", kakaoOauthConfig.scope()))
+                .toUriString();
+    }
+}

--- a/src/main/java/com/jisungin/infra/oauth/config/HttpInterfaceConfig.java
+++ b/src/main/java/com/jisungin/infra/oauth/config/HttpInterfaceConfig.java
@@ -1,0 +1,25 @@
+package com.jisungin.infra.oauth.config;
+
+import com.jisungin.infra.oauth.kakao.client.KakaoApiClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class HttpInterfaceConfig {
+
+    @Bean
+    public KakaoApiClient kakaoApiClient() {
+        return createHttpInterface(KakaoApiClient.class);
+    }
+
+    private <T> T createHttpInterface(Class<T> tClass) {
+        WebClient webClient = WebClient.create();
+        HttpServiceProxyFactory build = HttpServiceProxyFactory
+                .builder(WebClientAdapter.forClient(webClient)).build();
+        return build.createClient(tClass);
+    }
+
+}

--- a/src/main/java/com/jisungin/infra/oauth/kakao/KakaoOauthConfig.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/KakaoOauthConfig.java
@@ -1,0 +1,12 @@
+package com.jisungin.infra.oauth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOauthConfig(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String[] scope
+) {
+}

--- a/src/main/java/com/jisungin/infra/oauth/kakao/KakaoUserClient.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/KakaoUserClient.java
@@ -1,0 +1,43 @@
+package com.jisungin.infra.oauth.kakao;
+
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.oauth.client.UserClient;
+import com.jisungin.domain.user.User;
+import com.jisungin.infra.oauth.kakao.client.KakaoApiClient;
+import com.jisungin.infra.oauth.kakao.dto.KakaoToken;
+import com.jisungin.infra.oauth.kakao.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoUserClient implements UserClient {
+
+    private final KakaoApiClient kakaoApiClient;
+    private final KakaoOauthConfig kakaoOauthConfig;
+
+    @Override
+    public OauthType supportType() {
+        return OauthType.KAKAO;
+    }
+
+    @Override
+    public User fetch(String authCode) {
+        KakaoToken tokenInfo = kakaoApiClient.fetchToken(tokenRequestParams(authCode));
+        KakaoUserResponse kakaoUserResponse = kakaoApiClient.fetchUser("Bearer " + tokenInfo.accessToken());
+        return kakaoUserResponse.toEntity();
+    }
+
+    private MultiValueMap<String, String> tokenRequestParams(String authCode) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoOauthConfig.clientId());
+        params.add("redirect_uri", kakaoOauthConfig.redirectUri());
+        params.add("code", authCode);
+        params.add("client_secret", kakaoOauthConfig.clientSecret());
+        return params;
+    }
+
+}

--- a/src/main/java/com/jisungin/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/client/KakaoApiClient.java
@@ -1,0 +1,22 @@
+package com.jisungin.infra.oauth.kakao.client;
+
+import com.jisungin.infra.oauth.kakao.dto.KakaoToken;
+import com.jisungin.infra.oauth.kakao.dto.KakaoUserResponse;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.*;
+
+public interface KakaoApiClient {
+
+    @PostExchange(url = "https://kauth.kakao.com/oauth/token", contentType = APPLICATION_FORM_URLENCODED_VALUE)
+    KakaoToken fetchToken(@RequestParam MultiValueMap<String, String> params);
+
+    @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
+    KakaoUserResponse fetchUser (@RequestHeader(name = AUTHORIZATION) String bearerToken);
+
+}

--- a/src/main/java/com/jisungin/infra/oauth/kakao/dto/KakaoToken.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/dto/KakaoToken.java
@@ -1,0 +1,16 @@
+package com.jisungin.infra.oauth.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record KakaoToken(
+        String tokenType,
+        String accessToken,
+        String idToken,
+        Integer expiresIn,
+        String refreshToken,
+        Integer refreshTokenExpiresIn,
+        String scope
+) {
+}

--- a/src/main/java/com/jisungin/infra/oauth/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/dto/KakaoUserResponse.java
@@ -1,0 +1,70 @@
+package com.jisungin.infra.oauth.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.jisungin.domain.oauth.OauthId;
+import com.jisungin.domain.user.User;
+
+import java.time.LocalDateTime;
+
+import static com.jisungin.domain.oauth.OauthType.*;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record KakaoUserResponse(
+        Long id,
+        boolean hasSignedUp,
+        LocalDateTime connectedAt,
+        KakaoAccount kakaoAccount
+) {
+
+    public User toEntity() {
+        return User.builder()
+                .oauthId(OauthId.builder()
+                        .oauthId(String.valueOf(id))
+                        .oauthType(KAKAO)
+                        .build()
+                )
+                .name(kakaoAccount.profile.nickname)
+                .profileImage(kakaoAccount.profile.profileImageUrl)
+                .build();
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record KakaoAccount(
+            boolean profileNeedsAgreement,
+            boolean profileNicknameNeedsAgreement,
+            boolean profileImageNeedsAgreement,
+            Profile profile,
+            boolean nameNeedsAgreement,
+            String name,
+            boolean emailNeedsAgreement,
+            boolean isEmailValid,
+            boolean isEmailVerified,
+            String email,
+            boolean ageRangeNeedsAgreement,
+            String ageRange,
+            boolean birthyearNeedsAgreement,
+            String birthyear,
+            boolean birthdayNeedsAgreement,
+            String birthday,
+            String birthdayType,
+            boolean genderNeedsAgreement,
+            String gender,
+            boolean phoneNumberNeedsAgreement,
+            String phoneNumber,
+            boolean ciNeedsAgreement,
+            String ci,
+            LocalDateTime ciAuthenticatedAt
+    ) {
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record Profile(
+            String nickname,
+            String thumbnailImageUrl,
+            String profileImageUrl,
+            boolean isDefaultImage
+    ) {
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,4 @@ spring:
       prod-env:
         - prod
     include:
+      oauth


### PR DESCRIPTION
## 💡 연관된 이슈
close #1  

## 📝 작업 내용
- 소셜 로그인 요청 시 해당 서비스 로그인 화면으로 Redirect 하는 기능 구현
   - 현재는 카카오만 가능
- 프론트단에서 넘겨주는 인증 코드로 AccessToken을 발급 받는 기능 구현
   - AccessToken으로 사용자 정보를 가져와서 회원가입 / 로그인 가능

## 💬 리뷰 요구 사항
안녕하세요 ~ 소셜 로그인 관련 첫 PR입니다.
처음에는 스프링 시큐리티를 사용해서 구현하려고 했지만 의존도가 높아지는 것 같아 시큐리티 없이 구현했습니다.
결과적으론 시큐리티에 대한 의존성은 없어졌지만 로직 자체는 조금 복잡해진 것 같습니다.

![image](https://github.com/jisung-in/backend/assets/58456758/591c8c25-37e9-40a9-ae57-59372bf78f75)

일단 프론트단에서 사용자가 로그인 & 정보 제공 동의를 완료하면 인증 서버가 프론트단한테 인증 코드를 보내는 부분이 4번 과정입니다.
4번 Redirect 과정에서 인증 코드를 꺼내서 서버에 인증 코드와 함께  POST 요청을 해야 로직이 수행됩니다.
제가 구현한 부분은 4번 중간부터 구현했다고 보시면 될 거 같습니다.

코드에서 궁금한 점이나 피드백 있으시면 편하게 달아주세요.
또한 블로그 글을 작성했으니 참고하시고 질문 달아주셔도 좋을 것 같아요 👍 
🔥  https://trysolve.tistory.com/25 🔥 
