### PR TITLE
[Feature] TalkRoom 수정 API 구현

### DIFF
--- a/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
+++ b/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
@@ -21,12 +21,12 @@ public class TalkRoomController {
     private final TalkRoomService talkRoomService;
 
     // TODO. 회원 도메인이 개발되면 변경 예정
-    @PostMapping("/talk-room/create")
+    @PostMapping("/talk-rooms")
     public ApiResponse<TalkRoomResponse> createTalkRoom(@Valid @RequestBody TalkRoomCreateRequest request) {
         return ApiResponse.ok(talkRoomService.createTalkRoom(request.toServiceRequest(), "user@gmail.com"));
     }
 
-    @PatchMapping("/talk-room/edit")
+    @PatchMapping("/talk-rooms")
     public ApiResponse<TalkRoomResponse> editTalkRoom(@Valid @RequestBody TalkRoomEditRequest request) {
         return ApiResponse.ok(talkRoomService.editTalkRoom(request.toServiceRequest(), "user@gmail.com"));
     }

--- a/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
+++ b/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
@@ -2,10 +2,12 @@ package com.jisungin.api.talkroom;
 
 import com.jisungin.api.ApiResponse;
 import com.jisungin.api.talkroom.request.TalkRoomCreateRequest;
+import com.jisungin.api.talkroom.request.TalkRoomEditRequest;
 import com.jisungin.application.talkroom.TalkRoomService;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +24,11 @@ public class TalkRoomController {
     @PostMapping("/talk-room/create")
     public ApiResponse<TalkRoomResponse> createTalkRoom(@Valid @RequestBody TalkRoomCreateRequest request) {
         return ApiResponse.ok(talkRoomService.createTalkRoom(request.toServiceRequest(), "user@gmail.com"));
+    }
+
+    @PatchMapping("/talk-room/edit")
+    public ApiResponse<TalkRoomResponse> editTalkRoom(@Valid @RequestBody TalkRoomEditRequest request) {
+        return ApiResponse.ok(talkRoomService.editTalkRoom(request.toServiceRequest(), "user@gmail.com"));
     }
 
 }

--- a/src/main/java/com/jisungin/api/talkroom/request/TalkRoomEditRequest.java
+++ b/src/main/java/com/jisungin/api/talkroom/request/TalkRoomEditRequest.java
@@ -1,0 +1,39 @@
+package com.jisungin.api.talkroom.request;
+
+import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomEditRequest {
+
+    private Long id;
+
+    @Size(min = 1, max = 2000, message = "2000자 이하로 작성해야 합니다.")
+    private String content;
+
+    @NotEmpty(message = "참가 조건은 1개 이상 체크해야합니다.")
+    private List<String> readingStatus = new ArrayList<>();
+
+    @Builder
+    private TalkRoomEditRequest(Long id, String content, List<String> readingStatus) {
+        this.id = id;
+        this.content = content;
+        this.readingStatus = readingStatus;
+    }
+
+    public TalkRoomEditServiceRequest toServiceRequest() {
+        return TalkRoomEditServiceRequest.builder()
+                .id(id)
+                .content(content)
+                .readingStatus(readingStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
+++ b/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
@@ -54,10 +54,9 @@ public class TalkRoomService {
         User user = userRepository.findByName(userEmail)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        TalkRoom talkRoom = talkRoomRepository.findById(request.getId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.TALK_ROOM_NOT_FOUND));
+        TalkRoom talkRoom = talkRoomRepository.findByIdWithUser(request.getId());
 
-        if (!user.getId().equals(talkRoom.getUser().getId())) {
+        if (!talkRoom.isTalkRoomOwner(user.getId())) {
             throw new BusinessException(ErrorCode.ACCESS_PERMISSION_ERROR);
         }
 

--- a/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
+++ b/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
@@ -1,6 +1,7 @@
 package com.jisungin.application.talkroom;
 
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
@@ -39,6 +40,30 @@ public class TalkRoomService {
 
         TalkRoom talkRoom = TalkRoom.create(request, book, user);
         talkRoomRepository.save(talkRoom);
+
+        List<ReadingStatus> readingStatus = ReadingStatus.createReadingStatus(request.getReadingStatus());
+
+        readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
+                .forEach(talkRoomRoleRepository::save);
+
+        return TalkRoomResponse.of(talkRoom, readingStatus);
+    }
+
+    @Transactional
+    public TalkRoomResponse editTalkRoom(TalkRoomEditServiceRequest request, String userEmail) {
+        User user = userRepository.findByName(userEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        TalkRoom talkRoom = talkRoomRepository.findById(request.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.TALK_ROOM_NOT_FOUND));
+
+        if (!user.getId().equals(talkRoom.getUser().getId())) {
+            throw new BusinessException(ErrorCode.ACCESS_PERMISSION_ERROR);
+        }
+
+        talkRoom.edit(request);
+
+        talkRoomRoleRepository.deleteAllByTalkRoom(talkRoom);
 
         List<ReadingStatus> readingStatus = ReadingStatus.createReadingStatus(request.getReadingStatus());
 

--- a/src/main/java/com/jisungin/application/talkroom/request/TalkRoomEditServiceRequest.java
+++ b/src/main/java/com/jisungin/application/talkroom/request/TalkRoomEditServiceRequest.java
@@ -1,0 +1,29 @@
+package com.jisungin.application.talkroom.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomEditServiceRequest {
+
+    private Long id;
+
+    @Size(min = 1, max = 2000, message = "2000자 이하로 작성해야 합니다.")
+    private String content;
+
+    @NotEmpty(message = "참가 조건은 1개 이상 체크해야합니다.")
+    private List<String> readingStatus;
+
+    @Builder
+    private TalkRoomEditServiceRequest(Long id, String content, List<String> readingStatus) {
+        this.id = id;
+        this.content = content;
+        this.readingStatus = readingStatus;
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/talkroom/TalkRoom.java
+++ b/src/main/java/com/jisungin/domain/talkroom/TalkRoom.java
@@ -1,6 +1,7 @@
 package com.jisungin.domain.talkroom;
 
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
 import com.jisungin.domain.BaseEntity;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.user.User;
@@ -53,6 +54,10 @@ public class TalkRoom extends BaseEntity {
                 .user(user)
                 .content(request.getContent())
                 .build();
+    }
+
+    public void edit(TalkRoomEditServiceRequest request) {
+        this.content = request.getContent() != null ? request.getContent() : content;
     }
 
 }

--- a/src/main/java/com/jisungin/domain/talkroom/TalkRoom.java
+++ b/src/main/java/com/jisungin/domain/talkroom/TalkRoom.java
@@ -60,4 +60,8 @@ public class TalkRoom extends BaseEntity {
         this.content = request.getContent() != null ? request.getContent() : content;
     }
 
+    public boolean isTalkRoomOwner(Long userId) {
+        return user.isMe(userId);
+    }
+
 }

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepository.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepository.java
@@ -2,9 +2,15 @@ package com.jisungin.domain.talkroom.repository;
 
 import com.jisungin.domain.talkroom.TalkRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TalkRoomRepository extends JpaRepository<TalkRoom, Long> {
 
+    @Query(
+            "select t from TalkRoom t join t.user u where t.id = :talkRoomId"
+    )
+    TalkRoom findByIdWithUser(@Param("talkRoomId") Long talkRoomId);
 }

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRoleRepository.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRoleRepository.java
@@ -2,14 +2,10 @@ package com.jisungin.domain.talkroom.repository;
 
 import com.jisungin.domain.talkroom.TalkRoom;
 import com.jisungin.domain.talkroom.TalkRoomRole;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TalkRoomRoleRepository extends JpaRepository<TalkRoomRole, Long> {
 
-    List<TalkRoomRole> findByTalkRoom(TalkRoom talkRoom);
-
-    List<TalkRoomRole> findAllByTalkRoom(TalkRoom talkRoom);
-
     void deleteAllByTalkRoom(TalkRoom talkRoom);
+
 }

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRoleRepository.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRoleRepository.java
@@ -1,8 +1,15 @@
 package com.jisungin.domain.talkroom.repository;
 
+import com.jisungin.domain.talkroom.TalkRoom;
 import com.jisungin.domain.talkroom.TalkRoomRole;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TalkRoomRoleRepository extends JpaRepository<TalkRoomRole, Long> {
 
+    List<TalkRoomRole> findByTalkRoom(TalkRoom talkRoom);
+
+    List<TalkRoomRole> findAllByTalkRoom(TalkRoom talkRoom);
+
+    void deleteAllByTalkRoom(TalkRoom talkRoom);
 }

--- a/src/main/java/com/jisungin/domain/user/User.java
+++ b/src/main/java/com/jisungin/domain/user/User.java
@@ -2,7 +2,14 @@ package com.jisungin.domain.user;
 
 import com.jisungin.domain.BaseEntity;
 import com.jisungin.domain.oauth.OauthId;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,4 +52,7 @@ public class User extends BaseEntity {
         this.profileImage = profileImage;
     }
 
+    public boolean isMe(Long userId) {
+        return this.id.equals(userId);
+    }
 }

--- a/src/main/java/com/jisungin/exception/ErrorCode.java
+++ b/src/main/java/com/jisungin/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     BOOK_NOT_FOUND(404, "책을 찾을 수 없습니다."),
     BOOK_ALREADY_EXIST(400, "이미 등록된 책 정보 입니다."),
     PARTICIPATION_CONDITION_ERROR(400, "참가 조건은 1개 이상이어야 합니다."),
-    OAUTH_TYPE_NOT_FOUND(404, "지원하지 않는 소셜 로그인입니다.");
+    OAUTH_TYPE_NOT_FOUND(404, "지원하지 않는 소셜 로그인입니다."),
+    TALK_ROOM_NOT_FOUND(400, "토크방을 찾을 수 없습니다."),
+    ACCESS_PERMISSION_ERROR(400, "권한이 없는 사용자입니다.");
 
 
     private final int code;

--- a/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
+++ b/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
@@ -85,7 +85,7 @@ class TalkRoomControllerTest {
                 .build();
 
         // when // then
-        mockMvc.perform(post("/v1/talk-room/create")
+        mockMvc.perform(post("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -115,7 +115,7 @@ class TalkRoomControllerTest {
                 .build();
 
         // when // then
-        mockMvc.perform(post("/v1/talk-room/create")
+        mockMvc.perform(post("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -152,7 +152,7 @@ class TalkRoomControllerTest {
                 .build();
 
         // when // then
-        mockMvc.perform(patch("/v1/talk-room/edit")
+        mockMvc.perform(patch("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -192,7 +192,7 @@ class TalkRoomControllerTest {
                 .readingStatus(readingStatus)
                 .build();
         // when // then
-        mockMvc.perform(patch("/v1/talk-room/edit")
+        mockMvc.perform(patch("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -226,7 +226,7 @@ class TalkRoomControllerTest {
                 .readingStatus(null)
                 .build();
         // when // then
-        mockMvc.perform(patch("/v1/talk-room/edit")
+        mockMvc.perform(patch("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -276,7 +276,7 @@ class TalkRoomControllerTest {
                 .build();
 
         // when // then
-        mockMvc.perform(patch("/v1/talk-room/edit")
+        mockMvc.perform(patch("/v1/talk-rooms")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )
@@ -319,11 +319,10 @@ class TalkRoomControllerTest {
     }
 
     private static Book createBook() {
-        String author = "작가";
         return Book.builder()
                 .title("제목")
                 .content("내용")
-                .authors(author)
+                .authors("작가")
                 .isbn("11111")
                 .publisher("publisher")
                 .dateTime(LocalDateTime.now())

--- a/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
+++ b/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
@@ -2,14 +2,18 @@ package com.jisungin.application.service.talkroom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.tuple;
 
 import com.jisungin.application.talkroom.TalkRoomService;
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
+import com.jisungin.domain.oauth.OauthId;
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.talkroom.TalkRoom;
+import com.jisungin.domain.talkroom.TalkRoomRole;
 import com.jisungin.domain.talkroom.repository.TalkRoomRepository;
 import com.jisungin.domain.talkroom.repository.TalkRoomRoleRepository;
 import com.jisungin.domain.user.User;
@@ -76,15 +80,17 @@ class TalkRoomServiceTest {
         TalkRoomResponse response = talkRoomService.createTalkRoom(request, user.getName());
 
         // then
-        assertThat(response.getId()).isNotNull();
-        assertThat(response.getContent()).isEqualTo("토크방");
-        assertThat(response.getReadingStatuses()).hasSize(2)
-                .contains(ReadingStatus.READ, ReadingStatus.READING);
+        List<ReadingStatus> readingStatuses = response.getReadingStatuses();
+        List<TalkRoom> talkRooms = talkRoomRepository.findAll();
+        assertThat(response)
+                .extracting("id", "content")
+                .contains(talkRooms.get(0).getId(), "토크방");
+        assertThat(readingStatuses.size()).isEqualTo(2);
     }
 
     @Test
     @DisplayName("토크방을 생성할 때 참가 조건은 1개 이상이어야 한다.")
-    void createTalkRoomWithReadingStatus() {
+    void createTalkRoomWithNotReadingStatus() {
         // given
         User user = createUser();
         userRepository.save(user);
@@ -106,18 +112,200 @@ class TalkRoomServiceTest {
                 .hasMessage("참가 조건은 1개 이상이어야 합니다.");
     }
 
+    @Test
+    @DisplayName("토크방을 생성했던 사용자가 토크방의 제목을 수정한다.")
+    void editTalkRoom() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+        List<Book> books = bookRepository.findAll();
+
+        TalkRoom talkRoom = createTalkRoom(book, user);
+        talkRoomRepository.save(talkRoom);
+        List<TalkRoom> talkRooms = talkRoomRepository.findAll();
+
+        createTalkRoomRole(talkRoom);
+        List<TalkRoomRole> talkRoomRoles = talkRoomRoleRepository.findAll();
+
+        List<String> readingStatus = new ArrayList<>();
+        readingStatus.add("읽는 중");
+        readingStatus.add("읽음");
+
+        TalkRoomEditServiceRequest request = TalkRoomEditServiceRequest.builder()
+                .id(talkRooms.get(0).getId())
+                .content("토크방 수정")
+                .readingStatus(readingStatus)
+                .build();
+        // when
+        TalkRoomResponse response = talkRoomService.editTalkRoom(request, "user@gmail.com");
+
+        // then
+        assertThat(response)
+                .extracting("id", "content")
+                .contains(talkRooms.get(0).getId(), "토크방 수정");
+        assertThat(talkRoomRoles.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("토크방을 생성한 사용자가 토크방의 제목을 NULL 값으로 업데이트하려고 시도했을 때, 원래의 제목이 유지된다.")
+    void editTalkRoomWithNullContent() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+        List<Book> books = bookRepository.findAll();
+
+        TalkRoom talkRoom = createTalkRoom(book, user);
+        talkRoomRepository.save(talkRoom);
+        List<TalkRoom> talkRooms = talkRoomRepository.findAll();
+
+        createTalkRoomRole(talkRoom);
+        List<TalkRoomRole> talkRoomRoles = talkRoomRoleRepository.findAll();
+
+        List<String> readingStatus = new ArrayList<>();
+        readingStatus.add("읽는 중");
+        readingStatus.add("읽음");
+
+        TalkRoomEditServiceRequest request = TalkRoomEditServiceRequest.builder()
+                .id(talkRooms.get(0).getId())
+                .content(null)
+                .readingStatus(readingStatus)
+                .build();
+        // when
+        TalkRoomResponse response = talkRoomService.editTalkRoom(request, "user@gmail.com");
+
+        // then
+        assertThat(response)
+                .extracting("id", "content")
+                .contains(talkRooms.get(0).getId(), "토크방");
+        assertThat(talkRoomRoles.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("토크방을 생성했던 사용자가 토크방의 참가 조건을 수정한다.")
+    void editTalkRoomReadingStatus() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+        List<Book> books = bookRepository.findAll();
+
+        TalkRoom talkRoom = createTalkRoom(book, user);
+        talkRoomRepository.save(talkRoom);
+        List<TalkRoom> talkRooms = talkRoomRepository.findAll();
+
+        createTalkRoomRole(talkRoom);
+
+        List<String> readingStatus = new ArrayList<>();
+        readingStatus.add("읽는 중");
+        readingStatus.add("읽음");
+        readingStatus.add("잠시 멈춤");
+
+        TalkRoomEditServiceRequest request = TalkRoomEditServiceRequest.builder()
+                .id(talkRooms.get(0).getId())
+                .content("토크방")
+                .readingStatus(readingStatus)
+                .build();
+        // when
+        TalkRoomResponse response = talkRoomService.editTalkRoom(request, "user@gmail.com");
+
+        // then
+        List<TalkRoomRole> talkRoomRoles = talkRoomRoleRepository.findAll();
+        assertThat(response)
+                .extracting("id", "content")
+                .contains(talkRooms.get(0).getId(), "토크방");
+        assertThat(talkRoomRoles.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("토크방을 생성한 유저와 토크방을 수정하는 유저가 일치하지 않으면 예외가 발생한다.")
+    void editTalkRoomWithUsersMustMatch() {
+        // given
+        User userA = createUser();
+        userRepository.save(userA);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        TalkRoom talkRoom = createTalkRoom(book, userA);
+        talkRoomRepository.save(talkRoom);
+        List<TalkRoom> talkRooms = talkRoomRepository.findAll();
+
+        createTalkRoomRole(talkRoom);
+
+        User userB = User.builder()
+                .name("userB@gmail.com")
+                .oauthId(
+                        OauthId.builder()
+                                .oauthId("oauthId2")
+                                .oauthType(OauthType.KAKAO)
+                                .build()
+                )
+                .profileImage("image")
+                .build();
+        userRepository.save(userB);
+
+        List<String> readingStatus = new ArrayList<>();
+        readingStatus.add("읽는 중");
+        readingStatus.add("읽음");
+        readingStatus.add("잠시 멈춤");
+
+        TalkRoomEditServiceRequest request = TalkRoomEditServiceRequest.builder()
+                .id(talkRooms.get(0).getId())
+                .content("토크방")
+                .readingStatus(readingStatus)
+                .build();
+        // when // then
+        assertThatThrownBy(() -> talkRoomService.editTalkRoom(request, "userB@gmail.com"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("권한이 없는 사용자입니다.");
+    }
+
+    private void createTalkRoomRole(TalkRoom talkRoom) {
+        List<String> request = new ArrayList<>();
+        request.add("읽는 중");
+        request.add("읽음");
+
+        List<ReadingStatus> readingStatus = ReadingStatus.createReadingStatus(request);
+
+        readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
+                .forEach(talkRoomRoleRepository::save);
+    }
+
+    private static TalkRoom createTalkRoom(Book book, User user) {
+        return TalkRoom.builder()
+                .book(book)
+                .content("토크방")
+                .user(user)
+                .build();
+    }
+
     private static User createUser() {
         return User.builder()
                 .name("user@gmail.com")
-                .profile("image")
+                .profileImage("image")
+                .oauthId(
+                        OauthId.builder()
+                                .oauthId("oauthId")
+                                .oauthType(OauthType.KAKAO)
+                                .build()
+                )
                 .build();
     }
 
     private static Book createBook() {
+        String author = "작가";
         return Book.builder()
                 .title("제목")
                 .content("내용")
-                .authors("작가")
+                .authors(author)
                 .isbn("11111")
                 .publisher("publisher")
                 .dateTime(LocalDateTime.now())

--- a/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
+++ b/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
@@ -213,6 +213,7 @@ class TalkRoomServiceTest {
                 .content("토크방")
                 .readingStatus(readingStatus)
                 .build();
+
         // when
         TalkRoomResponse response = talkRoomService.editTalkRoom(request, "user@gmail.com");
 
@@ -301,11 +302,10 @@ class TalkRoomServiceTest {
     }
 
     private static Book createBook() {
-        String author = "작가";
         return Book.builder()
                 .title("제목")
                 .content("내용")
-                .authors(author)
+                .authors("작가")
                 .isbn("11111")
                 .publisher("publisher")
                 .dateTime(LocalDateTime.now())


### PR DESCRIPTION
## 💡 연관된 이슈
close #8

## 📝 작업 내용
* TalkRoom 수정 API 구현
* TalkRoom 수정 API 테스트 코드 작성

## 💬 리뷰 요구 사항
```java
public class TalkRoomEditRequest {

    private Long id;

    @Size(min = 1, max = 2000, message = "2000자 이하로 작성해야 합니다.")
    private String content;

    @NotEmpty(message = "참가 조건은 1개 이상 체크해야합니다.")
    private List<String> readingStatus = new ArrayList<>();

    ...
}
```
프론트단에서 변경된 참가 조건(ReadingStatus)이 `List<String>` 객체로 날라오게 됩니다. 근데 밑에 `Service` 로직을 보시면
```java
    @Transactional
    public TalkRoomResponse editTalkRoom(TalkRoomEditServiceRequest request, String userEmail) {
        User user = userRepository.findByName(userEmail)
                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));

        TalkRoom talkRoom = talkRoomRepository.findById(request.getId())
                .orElseThrow(() -> new BusinessException(ErrorCode.TALK_ROOM_NOT_FOUND));

        if (!user.getId().equals(talkRoom.getUser().getId())) {
            throw new BusinessException(ErrorCode.ACCESS_PERMISSION_ERROR);
        }

        talkRoom.edit(request);

        talkRoomRoleRepository.deleteAllByTalkRoom(talkRoom);

        List<ReadingStatus> readingStatus = ReadingStatus.createReadingStatus(request.getReadingStatus());

        readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
                .forEach(talkRoomRoleRepository::save);

        return TalkRoomResponse.of(talkRoom, readingStatus);
    }
```
만약 참가 조건(ReadingStatus)이 변경되었다면 원래 엔티티에 들어있는 값과 변경된 값 간의 비교를 통해 수정사항을 반영하려 했으나, 쿼리가 너무 복잡해질 것을 고려하여, 수정사항이 발생하면 해당 `TalkRoom`에 관련된 모든 참가 조건(ReadingStatus)을 삭제하고 다시 생성하는 로직으로 설계하였습니다. 
이 부분에 대해 좋은 생각이 있으시다면 리뷰 남겨주세요!!