### PR TITLE
[Feature] Spring MVC 인증 기능 구현

### DIFF
--- a/src/main/java/com/jisungin/api/oauth/Auth.java
+++ b/src/main/java/com/jisungin/api/oauth/Auth.java
@@ -1,0 +1,12 @@
+package com.jisungin.api.oauth;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/jisungin/api/oauth/AuthArgumentResolver.java
+++ b/src/main/java/com/jisungin/api/oauth/AuthArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.jisungin.api.oauth;
+
+import com.jisungin.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.jisungin.exception.ErrorCode.UNAUTHORIZED_REQUEST;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthContext authContext;
+
+    // 요청을 했을 때, @Auth와 내부 변수 타입이 Long인지 확인한다.
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    // userId를 확인하고 해당 값을 제공한다.
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+        if (authContext.getUserId() == null) {
+            // TODO. 추후에 인증과 관련된 예외처리를 적용할 예정
+            throw new BusinessException(UNAUTHORIZED_REQUEST);
+        }
+        return authContext.getUserId();
+    }
+
+}

--- a/src/main/java/com/jisungin/api/oauth/AuthConstant.java
+++ b/src/main/java/com/jisungin/api/oauth/AuthConstant.java
@@ -1,0 +1,7 @@
+package com.jisungin.api.oauth;
+
+public class AuthConstant {
+
+    public static final String JSESSION_ID = "JSESSIONID";
+
+}

--- a/src/main/java/com/jisungin/api/oauth/AuthContext.java
+++ b/src/main/java/com/jisungin/api/oauth/AuthContext.java
@@ -1,0 +1,20 @@
+package com.jisungin.api.oauth;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthContext {
+
+    private Long userId;
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+}

--- a/src/main/java/com/jisungin/api/oauth/AuthInterceptor.java
+++ b/src/main/java/com/jisungin/api/oauth/AuthInterceptor.java
@@ -1,0 +1,81 @@
+package com.jisungin.api.oauth;
+
+import com.jisungin.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PathMatcher;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.jisungin.api.oauth.AuthConstant.*;
+import static com.jisungin.exception.ErrorCode.UNAUTHORIZED_REQUEST;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final AuthContext authContext;
+    private final ObjectProvider<PathMatcher> pathMatcherProvider;
+    private final Set<UriAndMethodsCondition> authNotRequiredConditions = new HashSet<>();
+
+    public void setAuthNotRequiredConditions(UriAndMethodsCondition... authNotRequiredConditions) {
+        this.authNotRequiredConditions.clear();
+        this.authNotRequiredConditions.addAll(Arrays.asList(authNotRequiredConditions));
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        log.info("시작");
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
+        if (isAuthenticationNotRequired(request)) {
+            return true;
+        }
+
+        HttpSession session = getSession(request);
+        Long userId = Optional.ofNullable(session.getAttribute(JSESSION_ID))
+                .map(id -> (Long) id)
+                .orElseThrow(() -> new BusinessException(UNAUTHORIZED_REQUEST));
+        authContext.setUserId(userId);
+        return true;
+    }
+
+    private boolean isAuthenticationNotRequired(HttpServletRequest request) {
+        HttpMethod httpMethod = HttpMethod.valueOf(request.getMethod());
+        String requestURI = request.getRequestURI();
+        PathMatcher pathMatcher = pathMatcherProvider.getIfAvailable();
+        return authNotRequiredConditions.stream()
+                .anyMatch(it -> it.match(pathMatcher, requestURI, httpMethod));
+    }
+
+    private HttpSession getSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            // TODO. 추후에 인증과 관련된 예외처리를 적용할 예정
+            throw new BusinessException(UNAUTHORIZED_REQUEST);
+        }
+        return session;
+    }
+
+    public record UriAndMethodsCondition(String uriPattern, Set<HttpMethod> httpMethods) {
+        public boolean match(PathMatcher pathMatcher, String requestURI, HttpMethod httpMethod) {
+            return pathMatcher.match(uriPattern, requestURI) && httpMethods.contains(httpMethod);
+        }
+    }
+
+}

--- a/src/main/java/com/jisungin/api/oauth/OauthController.java
+++ b/src/main/java/com/jisungin/api/oauth/OauthController.java
@@ -3,10 +3,14 @@ package com.jisungin.api.oauth;
 import com.jisungin.api.ApiResponse;
 import com.jisungin.application.oauth.OauthService;
 import com.jisungin.domain.oauth.OauthType;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.web.bind.annotation.*;
+
+import static com.jisungin.api.oauth.AuthConstant.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,12 +31,26 @@ public class OauthController {
     }
 
     @GetMapping("/login/{oauthType}")
-    public ApiResponse<Long> login(
+    public ApiResponse<Void> login(
             @PathVariable OauthType oauthType,
-            @RequestParam("code") String code
+            @RequestParam("code") String code,
+            HttpServletRequest request
     ) {
-        Long login = oauthService.login(oauthType, code);
-        return ApiResponse.ok(login);
+        Long userId = oauthService.login(oauthType, code);
+        HttpSession session = request.getSession(true);
+        session.setAttribute(JSESSION_ID, userId);
+        return ApiResponse.ok(null);
+    }
+
+    @GetMapping("/logout/{oauthType}")
+    public ApiResponse<Void> logout(
+            @Auth Long userId,
+            @PathVariable OauthType oauthType,
+            HttpServletRequest request
+    ) {
+        oauthService.logout(oauthType, userId);
+        request.getSession(false).invalidate();
+        return ApiResponse.ok(null);
     }
 
 }

--- a/src/main/java/com/jisungin/application/oauth/OauthService.java
+++ b/src/main/java/com/jisungin/application/oauth/OauthService.java
@@ -5,6 +5,8 @@ import com.jisungin.domain.oauth.authcode.AuthCodeRequestUrlProviderComposite;
 import com.jisungin.domain.oauth.client.UserClientComposite;
 import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
+import com.jisungin.exception.BusinessException;
+import com.jisungin.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,12 @@ public class OauthService {
                 .orElseGet(() -> userRepository.save(user));
         // TODO. 추후에 다른 식별자로 구현할 예정
         return savedUser.getId();
+    }
+
+    public void logout(OauthType oauthType, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        userClientComposite.logout(oauthType, user.getOauthId());
     }
 
 }

--- a/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
+++ b/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
@@ -57,7 +57,7 @@ public class TalkRoomService {
         TalkRoom talkRoom = talkRoomRepository.findByIdWithUser(request.getId());
 
         if (!talkRoom.isTalkRoomOwner(user.getId())) {
-            throw new BusinessException(ErrorCode.ACCESS_PERMISSION_ERROR);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_REQUEST);
         }
 
         talkRoom.edit(request);

--- a/src/main/java/com/jisungin/config/AuthConfig.java
+++ b/src/main/java/com/jisungin/config/AuthConfig.java
@@ -1,0 +1,33 @@
+package com.jisungin.config;
+
+import com.jisungin.api.oauth.AuthArgumentResolver;
+import com.jisungin.api.oauth.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns(
+                        "/v1/oauth/logout/**"
+                );
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/oauth/client/UserClient.java
+++ b/src/main/java/com/jisungin/domain/oauth/client/UserClient.java
@@ -9,4 +9,6 @@ public interface UserClient {
 
     User fetch(String authCode);
 
+    void logout(String oauthId);
+
 }

--- a/src/main/java/com/jisungin/domain/oauth/client/UserClientComposite.java
+++ b/src/main/java/com/jisungin/domain/oauth/client/UserClientComposite.java
@@ -1,5 +1,6 @@
 package com.jisungin.domain.oauth.client;
 
+import com.jisungin.domain.oauth.OauthId;
 import com.jisungin.domain.oauth.OauthType;
 import com.jisungin.domain.user.User;
 import com.jisungin.exception.BusinessException;
@@ -27,6 +28,10 @@ public class UserClientComposite {
 
     public User fetch(OauthType oauthType, String authCode) {
         return getClient(oauthType).fetch(authCode);
+    }
+
+    public void logout(OauthType oauthType, OauthId oauthId) {
+        getClient(oauthType).logout(oauthId.getOauthId());
     }
 
     private UserClient getClient(OauthType oauthType) {

--- a/src/main/java/com/jisungin/domain/user/User.java
+++ b/src/main/java/com/jisungin/domain/user/User.java
@@ -55,4 +55,5 @@ public class User extends BaseEntity {
     public boolean isMe(Long userId) {
         return this.id.equals(userId);
     }
+
 }

--- a/src/main/java/com/jisungin/exception/ErrorCode.java
+++ b/src/main/java/com/jisungin/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     PARTICIPATION_CONDITION_ERROR(400, "참가 조건은 1개 이상이어야 합니다."),
     OAUTH_TYPE_NOT_FOUND(404, "지원하지 않는 소셜 로그인입니다."),
     TALK_ROOM_NOT_FOUND(400, "토크방을 찾을 수 없습니다."),
-    ACCESS_PERMISSION_ERROR(400, "권한이 없는 사용자입니다.");
+    UNAUTHORIZED_REQUEST(400, "권한이 없는 사용자입니다.");
 
 
     private final int code;

--- a/src/main/java/com/jisungin/infra/oauth/kakao/KakaoOauthConfig.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/KakaoOauthConfig.java
@@ -7,6 +7,7 @@ public record KakaoOauthConfig(
         String clientId,
         String clientSecret,
         String redirectUri,
-        String[] scope
+        String[] scope,
+        String adminKey
 ) {
 }

--- a/src/main/java/com/jisungin/infra/oauth/kakao/KakaoUserClient.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/KakaoUserClient.java
@@ -30,6 +30,14 @@ public class KakaoUserClient implements UserClient {
         return kakaoUserResponse.toEntity();
     }
 
+    @Override
+    public void logout(String oauthId) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", oauthId);
+        kakaoApiClient.logoutUser("KakaoAK " + kakaoOauthConfig.adminKey(), params);
+    }
+
     private MultiValueMap<String, String> tokenRequestParams(String authCode) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");

--- a/src/main/java/com/jisungin/infra/oauth/kakao/client/KakaoApiClient.java
+++ b/src/main/java/com/jisungin/infra/oauth/kakao/client/KakaoApiClient.java
@@ -3,6 +3,7 @@ package com.jisungin.infra.oauth.kakao.client;
 import com.jisungin.infra.oauth.kakao.dto.KakaoToken;
 import com.jisungin.infra.oauth.kakao.dto.KakaoUserResponse;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
@@ -17,6 +18,11 @@ public interface KakaoApiClient {
     KakaoToken fetchToken(@RequestParam MultiValueMap<String, String> params);
 
     @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
-    KakaoUserResponse fetchUser (@RequestHeader(name = AUTHORIZATION) String bearerToken);
+    KakaoUserResponse fetchUser(@RequestHeader(name = AUTHORIZATION) String bearerToken);
+
+    @PostExchange(url = "https://kapi.kakao.com/v1/user/logout")
+    void logoutUser(@RequestHeader(name = AUTHORIZATION) String adminKey,
+                    @RequestBody MultiValueMap<String, String> params
+    );
 
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #12 

## 📝 작업 내용
- 사용자 식별을 위한 Interceptor, Resolver 구현 
- 카카오 로그아웃 기능 구현
- OAuth 로그아웃 API 추가

## 💬 리뷰 요구 사항
구현한 로직의 예는 다음과 같습니다.

1. 프론트단에서 사용자의 세션 ID와 함께 로그아웃 API를 요청한다.
2. Interceptor의 preHandle에서 세션 ID를 꺼내서 AuthContext에 설정한다.
  2-1. 만약 세션 ID가 null이라면 예외가 발생한다.
3. Resolver에서 userId(세션 ID)을 `@Auth`에 매핑해서 반환한다.
  3-1. 넘어온 userId가 null이라면 예외가 발생한다.
4. 이제 컨트롤러는 `@Auth`에서 userId를 꺼내서 로그아웃 로직을 수행한다.

Interceptor와 Resolver의 자세한 내용은 아래 내용을 참고하시면 좋을 것 같습니다 !
https://tecoble.techcourse.co.kr/post/2021-05-24-spring-interceptor/

코드에서 궁금한 사항이나 의견이 있다면 남겨주세요 ~ 😊 