### PR TITLE
[Feature] TalkRoom 페이징 조회 API 구현

### DIFF
--- a/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
+++ b/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
@@ -3,10 +3,14 @@ package com.jisungin.api.talkroom;
 import com.jisungin.api.ApiResponse;
 import com.jisungin.api.talkroom.request.TalkRoomCreateRequest;
 import com.jisungin.api.talkroom.request.TalkRoomEditRequest;
+import com.jisungin.api.talkroom.request.TalkRoomSearchRequest;
 import com.jisungin.application.talkroom.TalkRoomService;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +28,11 @@ public class TalkRoomController {
     @PostMapping("/talk-rooms")
     public ApiResponse<TalkRoomResponse> createTalkRoom(@Valid @RequestBody TalkRoomCreateRequest request) {
         return ApiResponse.ok(talkRoomService.createTalkRoom(request.toServiceRequest(), "user@gmail.com"));
+    }
+
+    @GetMapping("talk-rooms")
+    public ApiResponse<TalkRoomPageResponse> getTalkRooms(@ModelAttribute TalkRoomSearchRequest search) {
+        return ApiResponse.ok(talkRoomService.getTalkRooms(search.toService()));
     }
 
     @PatchMapping("/talk-rooms")

--- a/src/main/java/com/jisungin/api/talkroom/request/TalkRoomSearchRequest.java
+++ b/src/main/java/com/jisungin/api/talkroom/request/TalkRoomSearchRequest.java
@@ -1,0 +1,35 @@
+package com.jisungin.api.talkroom.request;
+
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TalkRoomSearchRequest {
+
+    private Integer page = 1;
+
+    private Integer size = 10;
+
+    private String order;
+
+    @Builder
+    private TalkRoomSearchRequest(Integer page, Integer size, String order) {
+        this.page = page != null ? page : 1;
+        this.size = size != null ? size : 1;
+        this.order = order != null ? order : "recent";
+    }
+
+    public TalkRoomSearchServiceRequest toService() {
+        return TalkRoomSearchServiceRequest.builder()
+                .page(page)
+                .size(size)
+                .order(order)
+                .build();
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
+++ b/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
@@ -2,6 +2,8 @@ package com.jisungin.application.talkroom;
 
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
 import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
@@ -46,7 +48,11 @@ public class TalkRoomService {
         readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
                 .forEach(talkRoomRoleRepository::save);
 
-        return TalkRoomResponse.of(talkRoom, readingStatus);
+        return TalkRoomResponse.of(user.getName(), talkRoom, readingStatus, book.getUrl());
+    }
+
+    public TalkRoomPageResponse getTalkRooms(TalkRoomSearchServiceRequest search) {
+        return talkRoomRepository.getTalkRooms(search);
     }
 
     @Transactional
@@ -69,7 +75,7 @@ public class TalkRoomService {
         readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
                 .forEach(talkRoomRoleRepository::save);
 
-        return TalkRoomResponse.of(talkRoom, readingStatus);
+        return TalkRoomResponse.of(user.getName(), talkRoom, readingStatus, talkRoom.getBook().getUrl());
     }
 
 }

--- a/src/main/java/com/jisungin/application/talkroom/request/TalkRoomSearchServiceRequest.java
+++ b/src/main/java/com/jisungin/application/talkroom/request/TalkRoomSearchServiceRequest.java
@@ -1,0 +1,33 @@
+package com.jisungin.application.talkroom.request;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomSearchServiceRequest {
+
+    private static final int MAX_SIZE = 2000;
+
+    private Integer page;
+
+    private Integer size;
+
+    private String order;
+
+    @Builder
+    private TalkRoomSearchServiceRequest(Integer page, Integer size, String order) {
+        this.page = page;
+        this.size = size;
+        this.order = order;
+    }
+
+    public long getOffset() {
+        return (long) (max(1, page) - 1) * min(size, MAX_SIZE);
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/response/TalkRoomPageResponse.java
+++ b/src/main/java/com/jisungin/application/talkroom/response/TalkRoomPageResponse.java
@@ -1,0 +1,27 @@
+package com.jisungin.application.talkroom.response;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomPageResponse {
+
+    private List<TalkRoomQueryResponse> talkRoomQueryResponses = new ArrayList<>();
+
+    private long totalCount;
+
+    @Builder
+    private TalkRoomPageResponse(List<TalkRoomQueryResponse> talkRoomQueryResponses, long totalCount) {
+        this.talkRoomQueryResponses = talkRoomQueryResponses;
+        this.totalCount = totalCount;
+    }
+
+    public static long addTotalCountPage(long totalCount, Integer size) {
+        return (long) (Math.ceil((double) totalCount / size));
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/response/TalkRoomQueryReadingStatus.java
+++ b/src/main/java/com/jisungin/application/talkroom/response/TalkRoomQueryReadingStatus.java
@@ -1,0 +1,21 @@
+package com.jisungin.application.talkroom.response;
+
+import com.jisungin.domain.ReadingStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomQueryReadingStatus {
+
+    private ReadingStatus readingStatuses;
+
+    @Builder
+    @QueryProjection
+    public TalkRoomQueryReadingStatus(ReadingStatus readingStatuses) {
+        this.readingStatuses = readingStatuses;
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/response/TalkRoomQueryResponse.java
+++ b/src/main/java/com/jisungin/application/talkroom/response/TalkRoomQueryResponse.java
@@ -1,0 +1,33 @@
+package com.jisungin.application.talkroom.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TalkRoomQueryResponse {
+
+    private Long talkRoomId;
+    private String userName;
+    private String content;
+    private String bookImage;
+    private List<TalkRoomQueryReadingStatus> readingStatuses = new ArrayList<>();
+
+    @Builder
+    @QueryProjection
+    public TalkRoomQueryResponse(Long talkRoomId, String userName, String content, String bookImage) {
+        this.talkRoomId = talkRoomId;
+        this.userName = userName;
+        this.content = content;
+        this.bookImage = bookImage;
+    }
+
+    public void addTalkRoomStatus(List<TalkRoomQueryReadingStatus> readingStatuses) {
+        this.readingStatuses = readingStatuses;
+    }
+
+}

--- a/src/main/java/com/jisungin/application/talkroom/response/TalkRoomResponse.java
+++ b/src/main/java/com/jisungin/application/talkroom/response/TalkRoomResponse.java
@@ -2,29 +2,37 @@ package com.jisungin.application.talkroom.response;
 
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.talkroom.TalkRoom;
+import com.querydsl.core.annotations.QueryProjection;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class TalkRoomResponse {
 
-    private Long id;
+    private String userName;
     private String content;
     private List<ReadingStatus> readingStatuses;
+    private String bookImage;
 
     @Builder
-    private TalkRoomResponse(Long id, String content, List<ReadingStatus> readingStatuses) {
-        this.id = id;
+    @QueryProjection
+    public TalkRoomResponse(String userName, String content, List<ReadingStatus> readingStatuses, String bookImage) {
+        this.userName = userName;
         this.content = content;
         this.readingStatuses = readingStatuses;
+        this.bookImage = bookImage;
     }
 
-    public static TalkRoomResponse of(TalkRoom talkRoom, List<ReadingStatus> readingStatuses) {
+    public static TalkRoomResponse of(String userName, TalkRoom talkRoom, List<ReadingStatus> readingStatuses,
+                                      String bookImage) {
         return TalkRoomResponse.builder()
-                .id(talkRoom.getId())
+                .userName(userName)
                 .content(talkRoom.getContent())
                 .readingStatuses(readingStatuses)
+                .bookImage(bookImage)
                 .build();
     }
 

--- a/src/main/java/com/jisungin/config/QueryDslConfig.java
+++ b/src/main/java/com/jisungin/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.jisungin.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepository.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TalkRoomRepository extends JpaRepository<TalkRoom, Long> {
+public interface TalkRoomRepository extends JpaRepository<TalkRoom, Long>, TalkRoomRepositoryCustom {
 
     @Query(
             "select t from TalkRoom t join t.user u where t.id = :talkRoomId"

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryCustom.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jisungin.domain.talkroom.repository;
+
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
+
+public interface TalkRoomRepositoryCustom {
+
+    TalkRoomPageResponse getTalkRooms(TalkRoomSearchServiceRequest search);
+
+}

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImpl.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.jisungin.domain.talkroom.repository;
+
+import static com.jisungin.domain.book.QBook.book;
+import static com.jisungin.domain.talkroom.QTalkRoom.talkRoom;
+import static com.jisungin.domain.talkroom.QTalkRoomRole.talkRoomRole;
+import static com.jisungin.domain.user.QUser.user;
+
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import com.jisungin.application.talkroom.response.QTalkRoomQueryReadingStatus;
+import com.jisungin.application.talkroom.response.QTalkRoomQueryResponse;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
+import com.jisungin.application.talkroom.response.TalkRoomQueryReadingStatus;
+import com.jisungin.application.talkroom.response.TalkRoomQueryResponse;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TalkRoomRepositoryImpl implements TalkRoomRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public TalkRoomPageResponse getTalkRooms(TalkRoomSearchServiceRequest search) {
+
+        List<TalkRoomQueryResponse> findTalkRoom = findTalkRoom(search);
+
+        findTalkRoom.forEach(t -> {
+            List<TalkRoomQueryReadingStatus> talkRoomReadingStatus = findTalkRoomReadingStatus(t.getTalkRoomId());
+
+            t.addTalkRoomStatus(talkRoomReadingStatus);
+        });
+
+        long totalTalkRoom = getTotalTalkRoomCount();
+
+        long totalCountPage = TalkRoomPageResponse.addTotalCountPage(totalTalkRoom, search.getSize());
+
+        return TalkRoomPageResponse.builder()
+                .talkRoomQueryResponses(findTalkRoom)
+                .totalCount(totalCountPage)
+                .build();
+    }
+
+    private long getTotalTalkRoomCount() {
+        return queryFactory
+                .select(talkRoom.count())
+                .from(talkRoom)
+                .join(talkRoom.user, user)
+                .join(talkRoom.book, book)
+                .fetchOne();
+    }
+
+    private List<TalkRoomQueryResponse> findTalkRoom(TalkRoomSearchServiceRequest search) {
+        return queryFactory.select(new QTalkRoomQueryResponse(
+                        talkRoom.id.as("talkRoomId"),
+                        user.name.as("userName"),
+                        talkRoom.content,
+                        book.url.as("bookImage")
+                ))
+                .from(talkRoom)
+                .join(talkRoom.user, user)
+                .join(talkRoom.book, book)
+                .offset(search.getOffset())
+                .limit(search.getSize())
+                .orderBy(condition(search.getOrder()))
+                .fetch();
+    }
+
+    private List<TalkRoomQueryReadingStatus> findTalkRoomReadingStatus(Long talkRoomId) {
+        return queryFactory.select(new QTalkRoomQueryReadingStatus(
+                        talkRoomRole.readingStatus
+                ))
+                .from(talkRoomRole)
+                .join(talkRoomRole.talkRoom, talkRoom)
+                .where(talkRoomRole.talkRoom.id.eq(talkRoomId))
+                .fetch();
+    }
+
+    /**
+     * 아직 좋아요 기능이 구현 되지 않아 최신순으로만 정렬
+     */
+    private OrderSpecifier<?> condition(String order) {
+//         if (order.equals("recent"))
+        return talkRoom.id.desc();
+    }
+
+}

--- a/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
+++ b/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
@@ -1,6 +1,7 @@
 package com.jisungin.api.talkroom;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
 import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
@@ -24,6 +26,7 @@ import com.jisungin.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -284,6 +287,143 @@ class TalkRoomControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("권한이 없는 사용자입니다."));
+    }
+
+    @Test
+    @DisplayName("유저가 토크방 1페이지를 조회하면 최신순으로 10개의 토크방이 조회된다. 첫 번째 토크방의 이름은 토론방 102이다.")
+    void getTalkRooms() throws Exception {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .build();
+
+        // when // then
+        mockMvc.perform(get("/v1/talk-rooms?page=1&size=10&order=recent")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.talkRoomQueryResponses[0].content").value("토론방 102"));
+    }
+
+    @Test
+    @DisplayName("사용자가 토크방을 조회 했을 때 페이지를 -1 값을 보내면 첫 번째 페이지가 조회 되어야 한다. 첫 번째 토크방은 토론방 102이다.")
+    void getTalkRoomWithMinus() throws Exception {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .build();
+
+        // when // then
+        mockMvc.perform(get("/v1/talk-rooms?page=-1&size=10&order=recent")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.talkRoomQueryResponses[0].content").value("토론방 102"));
+    }
+
+    @Test
+    @DisplayName("사용자가 토크방을 조회 했을 때 페이지를 0 값을 보내면 첫 번째 페이지가 조회 되어야 한다. 첫 번째 토크방은 토론방 102이다.")
+    void getTalkRoomsWithZero() throws Exception {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .build();
+
+        // when // then
+        mockMvc.perform(get("/v1/talk-rooms?page=-1&size=10&order=recent")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.talkRoomQueryResponses[0].content").value("토론방 102"));
+    }
+
+    @Test
+    @DisplayName("토크방이 없을 때 토크방 조회 페이지에 들어갔을 때 에러가 발생하면 안된다.")
+    void getTalkRoomsEmpty() throws Exception {
+        // when // then
+        mockMvc.perform(get("/v1/talk-rooms?page=-1&size=10&order=recent")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
     }
 
     private void createTalkRoomRole(TalkRoom talkRoom) {

--- a/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
+++ b/src/test/java/com/jisungin/application/service/talkroom/TalkRoomServiceTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.jisungin.application.talkroom.TalkRoomService;
 import com.jisungin.application.talkroom.request.TalkRoomCreateServiceRequest;
 import com.jisungin.application.talkroom.request.TalkRoomEditServiceRequest;
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
@@ -22,6 +24,7 @@ import com.jisungin.exception.BusinessException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,8 +86,8 @@ class TalkRoomServiceTest {
         List<ReadingStatus> readingStatuses = response.getReadingStatuses();
         List<TalkRoom> talkRooms = talkRoomRepository.findAll();
         assertThat(response)
-                .extracting("id", "content")
-                .contains(talkRooms.get(0).getId(), "토크방");
+                .extracting("userName", "content")
+                .contains("user@gmail.com", "토크방");
         assertThat(readingStatuses.size()).isEqualTo(2);
     }
 
@@ -144,8 +147,8 @@ class TalkRoomServiceTest {
 
         // then
         assertThat(response)
-                .extracting("id", "content")
-                .contains(talkRooms.get(0).getId(), "토크방 수정");
+                .extracting("userName", "content")
+                .contains("user@gmail.com", "토크방 수정");
         assertThat(talkRoomRoles.size()).isEqualTo(2);
     }
 
@@ -181,8 +184,8 @@ class TalkRoomServiceTest {
 
         // then
         assertThat(response)
-                .extracting("id", "content")
-                .contains(talkRooms.get(0).getId(), "토크방");
+                .extracting("userName", "content")
+                .contains("user@gmail.com", "토크방");
         assertThat(talkRoomRoles.size()).isEqualTo(2);
     }
 
@@ -220,8 +223,8 @@ class TalkRoomServiceTest {
         // then
         List<TalkRoomRole> talkRoomRoles = talkRoomRoleRepository.findAll();
         assertThat(response)
-                .extracting("id", "content")
-                .contains(talkRooms.get(0).getId(), "토크방");
+                .extracting("userName", "content")
+                .contains("user@gmail.com", "토크방");
         assertThat(talkRoomRoles.size()).isEqualTo(3);
     }
 
@@ -267,6 +270,154 @@ class TalkRoomServiceTest {
         assertThatThrownBy(() -> talkRoomService.editTalkRoom(request, "userB@gmail.com"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("권한이 없는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("토크방을 최신순으로 10개의 토크방만 조회 했을 때, 첫 번째 토크방은 19번 토크방이다.")
+    void getTalkRooms() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 20)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .build();
+
+        // when
+        TalkRoomPageResponse talkRooms = talkRoomRepository.getTalkRooms(search);
+
+        // then
+        assertThat(10L).isEqualTo(talkRooms.getTalkRoomQueryResponses().size());
+        assertThat("토론방 19").isEqualTo(talkRooms.getTalkRoomQueryResponses().get(0).getContent());
+        assertThat(2).isEqualTo(talkRooms.getTalkRoomQueryResponses().get(0).getReadingStatuses().size());
+    }
+
+    @Test
+    @DisplayName("토크방이 총 103개가 생성 됐을 경우 페이지의 수는 11개여야 한다.")
+    void getTalkRoomsPageTotalCount() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .build();
+
+        // when
+        TalkRoomPageResponse talkRooms = talkRoomRepository.getTalkRooms(search);
+
+        // then
+        assertThat(11).isEqualTo(talkRooms.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("토크방 총 11페이지(103개) 중 5페이지를 조회를 조회하면 첫 번째 토크방은 62번 토크방이다.")
+    void getTalkRoomsMiddle() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(5)
+                .size(10)
+                .build();
+
+        // when
+        TalkRoomPageResponse talkRooms = talkRoomRepository.getTalkRooms(search);
+
+        // then
+        assertThat(talkRooms.getTalkRoomQueryResponses().size()).isEqualTo(10L);
+        assertThat(talkRooms.getTalkRoomQueryResponses().get(0).getContent()).isEqualTo("토론방 62");
+    }
+
+    @Test
+    @DisplayName("토크방 총 11 페이지(103개) 중 마지막 페이지를 조회하면 첫 번째 토크방은 2번 토크방이다.")
+    void getTalkRoomsLast() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 103)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(11)
+                .size(10)
+                .build();
+
+        // when
+        TalkRoomPageResponse talkRooms = talkRoomRepository.getTalkRooms(search);
+
+        // then
+        assertThat(talkRooms.getTalkRoomQueryResponses().size()).isEqualTo(3);
+        assertThat(talkRooms.getTalkRoomQueryResponses().get(0).getContent()).isEqualTo("토론방 2");
     }
 
     private void createTalkRoomRole(TalkRoom talkRoom) {

--- a/src/test/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImplTest.java
+++ b/src/test/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImplTest.java
@@ -1,0 +1,137 @@
+package com.jisungin.domain.talkroom.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jisungin.application.talkroom.TalkRoomService;
+import com.jisungin.application.talkroom.request.TalkRoomSearchServiceRequest;
+import com.jisungin.application.talkroom.response.TalkRoomPageResponse;
+import com.jisungin.domain.ReadingStatus;
+import com.jisungin.domain.book.Book;
+import com.jisungin.domain.book.repository.BookRepository;
+import com.jisungin.domain.oauth.OauthId;
+import com.jisungin.domain.oauth.OauthType;
+import com.jisungin.domain.talkroom.TalkRoom;
+import com.jisungin.domain.talkroom.TalkRoomRole;
+import com.jisungin.domain.user.User;
+import com.jisungin.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TalkRoomRepositoryImplTest {
+
+    @Autowired
+    TalkRoomRepository talkRoomRepository;
+
+    @Autowired
+    TalkRoomRoleRepository talkRoomRoleRepository;
+
+    @Autowired
+    TalkRoomService talkRoomService;
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        talkRoomRoleRepository.deleteAllInBatch();
+        talkRoomRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        bookRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("querydsl 페이징 조회 테스트")
+    void pageTest() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Book book = createBook();
+        bookRepository.save(book);
+
+        List<TalkRoom> talkRoom = IntStream.range(0, 20)
+                .mapToObj(i -> TalkRoom.builder()
+                        .user(user)
+                        .book(book)
+                        .content("토론방 " + i)
+                        .build())
+                .toList();
+
+        talkRoomRepository.saveAll(talkRoom);
+
+        for (TalkRoom t : talkRoom) {
+            createTalkRoomRole(t);
+        }
+
+        TalkRoomSearchServiceRequest search = TalkRoomSearchServiceRequest.builder()
+                .page(1)
+                .size(10)
+                .order(null)
+                .build();
+
+        // when
+        TalkRoomPageResponse talkRooms = talkRoomRepository.getTalkRooms(search);
+
+        // then
+        assertThat(10L).isEqualTo(talkRooms.getTalkRoomQueryResponses().size());
+        assertThat("토론방 19").isEqualTo(talkRooms.getTalkRoomQueryResponses().get(0).getContent());
+        assertThat(2).isEqualTo(talkRooms.getTalkRoomQueryResponses().get(0).getReadingStatuses().size());
+        assertThat(2).isEqualTo(talkRooms.getTotalCount());
+    }
+
+    private void createTalkRoomRole(TalkRoom talkRoom) {
+        List<String> request = new ArrayList<>();
+        request.add("읽는 중");
+        request.add("읽음");
+
+        List<ReadingStatus> readingStatus = ReadingStatus.createReadingStatus(request);
+
+        readingStatus.stream().map(status -> TalkRoomRole.roleCreate(talkRoom, status))
+                .forEach(talkRoomRoleRepository::save);
+    }
+
+    private static TalkRoom createTalkRoom(Book book, User user) {
+        return TalkRoom.builder()
+                .book(book)
+                .content("토크방")
+                .user(user)
+                .build();
+    }
+
+    private static User createUser() {
+        return User.builder()
+                .name("user@gmail.com")
+                .profileImage("image")
+                .oauthId(
+                        OauthId.builder()
+                                .oauthId("oauthId")
+                                .oauthType(OauthType.KAKAO)
+                                .build()
+                )
+                .build();
+    }
+
+    private static Book createBook() {
+        return Book.builder()
+                .title("제목")
+                .content("내용")
+                .authors("작가")
+                .isbn("11111")
+                .publisher("publisher")
+                .dateTime(LocalDateTime.now())
+                .url("www")
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close(#14)

## 📝 작업 내용
* TalkRoom 페이징 조회 API 기능 구현
* TalkRoom 페이징 조회 API 테스트 코드 작성

## 💬 리뷰 요구 사항
제가 구현한 페이징 로직 동작은 이러합니다.

1. 단방향 연관 관계로 인해 TalkRoomRole을 바로 조회할 수 없으므로, 먼저 해당 TalkRoom을 조회합니다.
2. TalkRoom에 연관된 user와 book을 join하여 찾아옵니다.
3. 조회된 TalkRoom의 id를 사용하여 관련된 TalkRoomRole을 추가로 조회합니다. 

##

`long totalTalkRoom = getTotalTalkRoomCount();` 여기가 전체 페이지 수를 계산해주는 로직인데, 이 로직을 TalkRoomPageResponse라는 DTO 안에 넣어두는 것이 나을까요? 아니면 조회 로직을 담당하는 Repository 안에 메소드를 만들어서 로직을 실행하는 편이 나을까요?
```java
// Repository
@Override
    public TalkRoomPageResponse getTalkRooms(TalkRoomSearchServiceRequest search) {

        List<TalkRoomQueryResponse> findTalkRoom = findTalkRoom(search);

        findTalkRoom.forEach(t -> {
            List<TalkRoomQueryReadingStatus> talkRoomReadingStatus = findTalkRoomReadingStatus(t.getTalkRoomId());

            t.addTalkRoomStatus(talkRoomReadingStatus);
        });

        long totalTalkRoom = getTotalTalkRoomCount();

        long totalCountPage = TalkRoomPageResponse.addTotalCountPage(totalTalkRoom, search.getSize());

        return TalkRoomPageResponse.builder()
                .talkRoomQueryResponses(findTalkRoom)
                .totalCount(totalCountPage)
                .build();
    }
```

```
// DTO
public class TalkRoomPageResponse {

    ...

    public static long addTotalCountPage(long totalCount, Integer size) {
        return (long) (Math.ceil((double) totalCount / size));
    }

}
```
