### PR TITLE
[Feature] TalkRoom 삭제 API 구현

### DIFF
--- a/src/main/java/com/jisungin/api/ApiResponse.java
+++ b/src/main/java/com/jisungin/api/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.jisungin.api;
 
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -11,6 +12,7 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
+    @Builder
     public ApiResponse(HttpStatus status, String message, T data) {
         this.code = status.value();
         this.status = status;

--- a/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
+++ b/src/main/java/com/jisungin/api/talkroom/TalkRoomController.java
@@ -13,6 +13,8 @@ import com.jisungin.application.talkroom.response.TalkRoomFindOneResponse;
 import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -51,6 +53,16 @@ public class TalkRoomController {
     public ApiResponse<TalkRoomResponse> editTalkRoom(@Valid @RequestBody TalkRoomEditRequest request,
                                                       @Auth AuthContext authContext) {
         return ApiResponse.ok(talkRoomService.editTalkRoom(request.toServiceRequest(), authContext.getUserId()));
+    }
+
+    @DeleteMapping("/talk-rooms/{talkRoomId}")
+    public ApiResponse<Void> deleteTalkRoom(@PathVariable Long talkRoomId, @Auth AuthContext authContext) {
+        talkRoomService.deleteTalkRoom(talkRoomId, authContext.getUserId());
+
+        return ApiResponse.<Void>builder()
+                .message("OK")
+                .status(HttpStatus.OK)
+                .build();
     }
 
 }

--- a/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
+++ b/src/main/java/com/jisungin/application/talkroom/TalkRoomService.java
@@ -10,7 +10,6 @@ import com.jisungin.application.talkroom.response.TalkRoomResponse;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
-import com.jisungin.domain.comment.Comment;
 import com.jisungin.domain.comment.repository.CommentRepository;
 import com.jisungin.domain.talkroom.TalkRoom;
 import com.jisungin.domain.talkroom.TalkRoomRole;
@@ -21,7 +20,6 @@ import com.jisungin.domain.user.repository.UserRepository;
 import com.jisungin.exception.BusinessException;
 import com.jisungin.exception.ErrorCode;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,8 +101,7 @@ public class TalkRoomService {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_REQUEST);
         }
 
-        Optional<Comment> comment = commentRepository.findByTalkRoom(talkRoom);
-        comment.ifPresent(commentRepository::delete);
+        commentRepository.findByTalkRoom(talkRoom).ifPresent(commentRepository::delete);
 
         talkRoomRoleRepository.deleteAllByTalkRoom(talkRoom);
         talkRoomRepository.delete(talkRoom);

--- a/src/main/java/com/jisungin/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/jisungin/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,13 @@
 package com.jisungin.domain.comment.repository;
 
 import com.jisungin.domain.comment.Comment;
+import com.jisungin.domain.talkroom.TalkRoom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    Optional<Comment> findByTalkRoom(TalkRoom talkRoom);
 }

--- a/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImpl.java
+++ b/src/main/java/com/jisungin/domain/talkroom/repository/TalkRoomRepositoryImpl.java
@@ -60,7 +60,6 @@ public class TalkRoomRepositoryImpl implements TalkRoomRepositoryCustom {
         findOneTalkRoom.addTalkRoomComments(talkRoomComments);
 
         return findOneTalkRoom;
-
     }
 
     private List<TalkRoomQueryComments> findCommentsByTalkRoomId(Long talkRoomId) {

--- a/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
+++ b/src/test/java/com/jisungin/api/talkroom/TalkRoomControllerTest.java
@@ -1,6 +1,7 @@
 package com.jisungin.api.talkroom;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -179,6 +180,20 @@ class TalkRoomControllerTest extends ControllerTestSupport {
     void findOneTalkRoom() throws Exception {
         // when // then
         mockMvc.perform(get("/v1/talk-room/1")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @Test
+    @DisplayName("토크방을 삭제한다.")
+    void deleteTalkRoom() throws Exception {
+        // when // then
+        mockMvc.perform(delete("/v1/talk-rooms/1")
                         .contentType(APPLICATION_JSON)
                 )
                 .andDo(print())


### PR DESCRIPTION
## 💡 연관된 이슈
close #36 

## 📝 작업 내용
* TalkRoom 삭제 API 구현
* TalkRoom 삭제 API 테스트 코드 작성

## 💬 리뷰 요구 사항
1. 프론트 단에서 `TalkRoom_ID`와 `Auth` 정보를 받아온다.
2. `TalkRoom_ID`를 바탕으로 해당 `TalkRoom`을 조회 후 `TalkRoom`을 생성한 `User_ID`와 `Auth_ID` 비교 후 일치하면 `TalkRoom`을 삭제한다.