### PR TITLE
[Refactor] 한줄평 페이지 조회 API의 별점 평균 정렬 방식 수정

### DIFF
--- a/src/main/java/com/jisungin/application/review/response/ReviewContentResponse.java
+++ b/src/main/java/com/jisungin/application/review/response/ReviewContentResponse.java
@@ -29,10 +29,13 @@ public class ReviewContentResponse {
 
     private String publisher;
 
+    private Long likeCount;
+
     @Builder
     @QueryProjection
     public ReviewContentResponse(Long reviewId, String userImage, String userName, Double rating, String content,
-                                 String isbn, String title, String bookImage, String authors, String publisher) {
+                                 String isbn, String title, String bookImage, String authors, String publisher,
+                                 Long likeCount) {
         this.reviewId = reviewId;
         this.userImage = userImage;
         this.userName = userName;
@@ -43,5 +46,7 @@ public class ReviewContentResponse {
         this.bookImage = bookImage;
         this.authors = authors;
         this.publisher = publisher;
+        this.likeCount = likeCount;
     }
+
 }

--- a/src/main/java/com/jisungin/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/jisungin/domain/review/repository/ReviewRepositoryImpl.java
@@ -83,11 +83,13 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .select(new QReviewContentResponse(
                         review.id, review.user.profileImage, review.user.name, rating1.rating, review.content,
                         review.book.isbn, review.book.title, review.book.imageUrl, review.book.authors,
-                        review.book.publisher
+                        review.book.publisher, reviewLike.id.count()
                 ))
                 .from(review)
                 .leftJoin(rating1).on(review.user.eq(rating1.user), review.book.eq(rating1.book))
+                .leftJoin(reviewLike).on(review.eq(reviewLike.review))
                 .where(review.user.id.eq(userId))
+                .groupBy(review.id)
                 .orderBy(createSpecifier(orderType), review.book.title.asc())
                 .offset(offset)
                 .limit(size)

--- a/src/test/java/com/jisungin/api/user/UserControllerTest.java
+++ b/src/test/java/com/jisungin/api/user/UserControllerTest.java
@@ -32,7 +32,7 @@ class UserControllerTest extends ControllerTestSupport {
     void getReviewContents() throws Exception {
         //given
         //when //then
-        mockMvc.perform(get("/v1/users/reviews?page=1&size=4&order=rating_asc")
+        mockMvc.perform(get("/v1/users/reviews?page=1&size=4&order=rating_avg_desc")
                         .contentType(APPLICATION_JSON)
                         .session(mockHttpSession)
                 )

--- a/src/test/java/com/jisungin/application/user/UserServiceTest.java
+++ b/src/test/java/com/jisungin/application/user/UserServiceTest.java
@@ -5,7 +5,7 @@ import static com.jisungin.domain.ReadingStatus.READ;
 import static com.jisungin.domain.ReadingStatus.READING;
 import static com.jisungin.domain.ReadingStatus.STOP;
 import static com.jisungin.domain.ReadingStatus.WANT;
-import static com.jisungin.domain.review.RatingOrderType.RATING_ASC;
+import static com.jisungin.domain.review.RatingOrderType.*;
 import static com.jisungin.domain.userlibrary.ReadingStatusOrderType.DICTIONARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -117,7 +117,8 @@ class UserServiceTest extends ServiceTestSupport {
         User user2 = userRepository.save(createUser("2"));
         List<Book> books = bookRepository.saveAll(createBooks());
         List<Review> reviews = reviewRepository.saveAll(createReviews(user1, books));
-        List<Rating> ratings = ratingRepository.saveAll(createRatings(user1, books));
+        List<Rating> ratings1 = ratingRepository.saveAll(createRatings(user1, books));
+        List<Rating> ratings2 = ratingRepository.saveAll(createRatings(user2, books));
         List<ReviewLike> reviewLikesWithUser1 = reviewLikeRepository.saveAll(createReviewLikes(user1, reviews));
         List<ReviewLike> reviewLikesWithUser2 = reviewLikeRepository.saveAll(createReviewLikes(user2, reviews));
 
@@ -125,7 +126,7 @@ class UserServiceTest extends ServiceTestSupport {
         ReviewContentGetAllServiceRequest request = ReviewContentGetAllServiceRequest.builder()
                 .page(1)
                 .size(4)
-                .orderType(RATING_ASC)
+                .orderType(RATING_AVG_ASC)
                 .build();
 
         //when

--- a/src/test/java/com/jisungin/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/jisungin/docs/user/UserControllerDocsTest.java
@@ -187,6 +187,8 @@ public class UserControllerDocsTest extends RestDocsSupport {
                                         .description("책 저자"),
                                 fieldWithPath("data.reviewContents.queryResponse[].publisher").type(JsonFieldType.STRING)
                                         .description("책 출판사"),
+                                fieldWithPath("data.reviewContents.queryResponse[].likeCount").type(JsonFieldType.NUMBER)
+                                        .description("좋아요 총개수"),
                                 fieldWithPath("data.reviewContents.totalCount").type(JsonFieldType.NUMBER)
                                         .description("총 리뷰 개수"),
                                 fieldWithPath("data.reviewContents.size").type(JsonFieldType.NUMBER)
@@ -328,6 +330,7 @@ public class UserControllerDocsTest extends RestDocsSupport {
                         .bookImage("bookImage" + i)
                         .authors("저자" + i)
                         .publisher("출판사" + i)
+                        .likeCount((long) i)
                         .build())
                 .toList();
     }

--- a/src/test/java/com/jisungin/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/jisungin/domain/review/repository/ReviewRepositoryTest.java
@@ -20,10 +20,12 @@ import com.jisungin.domain.user.OauthId;
 import com.jisungin.domain.user.OauthType;
 import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,13 +76,13 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
         //then
         assertThat(result.getTotalCount()).isEqualTo(20);
         assertThat(result.getQueryResponse()).hasSize(4)
-                .extracting(
-                        "userImage", "userName", "rating", "content", "isbn", "title", "bookImage")
+                .extracting("userImage", "userName", "rating", "content", "isbn", "title", "bookImage",
+                        "authors", "publisher", "likeCount")
                 .containsExactly(
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용1", "1", "제목1", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용11", "11", "제목11", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용16", "16", "제목16", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용6", "6", "제목6", "bookImage")
+                        tuple("userImage", "김도형", 1.0, "리뷰 내용1", "1", "제목1", "bookImage", "저자1", "출판사1", 2L),
+                        tuple("userImage", "김도형", 1.0, "리뷰 내용11", "11", "제목11", "bookImage", "저자11", "출판사11", 2L),
+                        tuple("userImage", "김도형", 1.0, "리뷰 내용16", "16", "제목16", "bookImage", "저자16", "출판사16", 2L),
+                        tuple("userImage", "김도형", 1.0, "리뷰 내용6", "6", "제목6", "bookImage", "저자6", "출판사6", 2L)
                 );
     }
 
@@ -88,7 +90,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     void findAllByBookById() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<Rating> ratings = ratingRepository.saveAll(createRatingsForBookWithUsers(users, book));
@@ -114,7 +116,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     void findAllByBookIdOrderByRecent() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<Rating> ratings = ratingRepository.saveAll(createRatingsForBookWithUsers(users, book));
@@ -146,7 +148,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     public void findAllBookIdOrderByRatingDesc() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<Rating> ratings = ratingRepository.saveAll(createRatingsForBookWithUsers(users, book));
@@ -172,7 +174,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     public void findAllBookIdOrderByRatingDescWithoutRating() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<ReviewLike> reviewLikes = reviewLikeRepository.saveAll(
@@ -195,7 +197,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     public void findAllBookIdOrderByRatingAsc() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<Rating> ratings = ratingRepository.saveAll(createRatingsForBookWithUsers(users, book));
@@ -221,7 +223,7 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     public void findAllBookIdOrderByRatingAscWithoutRating() {
         // given
-        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001"));
+        Book book = bookRepository.save(createBook("도서 제목", "도서 내용", "00001", "저자명", "출판사"));
         List<User> users = userRepository.saveAll(createUsers());
         List<Review> reviews = reviewRepository.saveAll(createReviewsForBook(users, book));
         List<ReviewLike> reviewLikes = reviewLikeRepository.saveAll(
@@ -243,17 +245,17 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     private static List<Book> createBooks() {
         return IntStream.rangeClosed(1, 20)
                 .mapToObj(i -> createBook(
-                        "제목" + String.valueOf(i), "내용" + String.valueOf(i), String.valueOf(i)))
+                        "제목" + i, "내용" + i, String.valueOf(i), "저자" + i, "출판사" + i))
                 .collect(Collectors.toList());
     }
 
-    private static Book createBook(String title, String content, String isbn) {
+    private static Book createBook(String title, String content, String isbn, String authors, String publisher) {
         return Book.builder()
                 .title(title)
                 .content(content)
-                .authors("김도형")
+                .authors(authors)
                 .isbn(isbn)
-                .publisher("지성인")
+                .publisher(publisher)
                 .dateTime(LocalDateTime.of(2024, 1, 1, 0, 0))
                 .imageUrl("bookImage")
                 .build();


### PR DESCRIPTION
## 💡 연관된 이슈
close #120 

## 📝 작업 내용
- 한줄평 페이지 조회 API의 별점 평균 정렬 방식을 수정
- 페이지 조회 시, 각 엔티티마다 총 좋아요 개수 필드 추가

## 💬 리뷰 요구 사항
특별히 없습니다 ~