### PR TITLE
[Refactor] 유저 관련 API 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+    targetCompatibility = '17'
 }
 
 configurations {

--- a/src/docs/asciidoc/api/library/library.adoc
+++ b/src/docs/asciidoc/api/library/library.adoc
@@ -36,11 +36,11 @@ include::{snippets}/library/delete/http-request.adoc[]
 include::{snippets}/library/delete/http-response.adoc[]
 include::{snippets}/library/delete/response-fields.adoc[]
 
-=== 독서 상태 페이지 조회
+=== 유저 독서 상태 페이지 조회
 ==== HTTP Request
-include::{snippets}/library/get-status/http-request.adoc[]
-include::{snippets}/library/get-status/query-parameters.adoc[]
+include::{snippets}/library/user-statuses/http-request.adoc[]
+include::{snippets}/library/user-statuses/query-parameters.adoc[]
 
 ==== HTTP Response
-include::{snippets}/library/get-status/http-response.adoc[]
-include::{snippets}/library/get-status/response-fields.adoc[]
+include::{snippets}/library/user-statuses/http-response.adoc[]
+include::{snippets}/library/user-statuses/response-fields.adoc[]

--- a/src/docs/asciidoc/api/rating/rating.adoc
+++ b/src/docs/asciidoc/api/rating/rating.adoc
@@ -50,15 +50,15 @@ include::{snippets}/rating/delete/path-parameters.adoc[]
 include::{snippets}/rating/delete/http-response.adoc[]
 include::{snippets}/rating/delete/response-fields.adoc[]
 
-[[rating-findAll]]
-=== 별점 페이지 조회
+[[rating-users]]
+=== 유저 별점 페이지 조회
 
 ==== HTTP Request
 
-include::{snippets}/rating/findAll/http-request.adoc[]
-include::{snippets}/rating/findAll/query-parameters.adoc[]
+include::{snippets}/rating/user-ratings/http-request.adoc[]
+include::{snippets}/rating/user-ratings/query-parameters.adoc[]
 
 ==== HTTP Response
 
-include::{snippets}/rating/findAll/http-response.adoc[]
-include::{snippets}/rating/findAll/response-fields.adoc[]
+include::{snippets}/rating/user-ratings/http-response.adoc[]
+include::{snippets}/rating/user-ratings/response-fields.adoc[]

--- a/src/docs/asciidoc/api/review/review.adoc
+++ b/src/docs/asciidoc/api/review/review.adoc
@@ -48,14 +48,14 @@ include::{snippets}/rating/delete/http-response.adoc[]
 include::{snippets}/rating/delete/response-fields.adoc[]
 
 [[review-findAll]]
-=== 한줄평 페이지 조회
+=== 유저 한줄평 페이지 조회
 
 ==== HTTP Request
 
-include::{snippets}/review/findAll/http-request.adoc[]
-include::{snippets}/review/findAll/query-parameters.adoc[]
+include::{snippets}/review/user-reviews/http-request.adoc[]
+include::{snippets}/review/user-reviews/query-parameters.adoc[]
 
 ==== HTTP Response
 
-include::{snippets}/review/findAll/http-response.adoc[]
-include::{snippets}/review/findAll/response-fields.adoc[]
+include::{snippets}/review/user-reviews/http-response.adoc[]
+include::{snippets}/review/user-reviews/response-fields.adoc[]

--- a/src/main/java/com/jisungin/api/library/LibraryController.java
+++ b/src/main/java/com/jisungin/api/library/LibraryController.java
@@ -3,20 +3,18 @@ package com.jisungin.api.library;
 import com.jisungin.api.ApiResponse;
 import com.jisungin.api.library.request.LibraryCreateRequest;
 import com.jisungin.api.library.request.LibraryEditRequest;
+import com.jisungin.api.library.request.UserReadingStatusGetAllRequest;
 import com.jisungin.api.support.Auth;
+import com.jisungin.application.PageResponse;
 import com.jisungin.application.library.LibraryService;
 import com.jisungin.application.library.response.LibraryResponse;
+import com.jisungin.application.library.response.UserReadingStatusResponse;
 import jakarta.validation.Valid;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,4 +54,13 @@ public class LibraryController {
         return ApiResponse.ok();
     }
 
+    @GetMapping("/users/libraries/statuses")
+    public ApiResponse<PageResponse<UserReadingStatusResponse>> getReadingStatuses(
+            @ModelAttribute UserReadingStatusGetAllRequest request,
+            @Auth Long userId
+    ) {
+        PageResponse<UserReadingStatusResponse> response = libraryService.getUserReadingStatuses(userId, request.toService());
+
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/com/jisungin/api/library/request/UserReadingStatusGetAllRequest.java
+++ b/src/main/java/com/jisungin/api/library/request/UserReadingStatusGetAllRequest.java
@@ -1,6 +1,6 @@
-package com.jisungin.api.user.request;
+package com.jisungin.api.library.request;
 
-import com.jisungin.application.user.request.UserReadingStatusGetAllServiceRequest;
+import com.jisungin.application.library.request.UserReadingStatusGetAllServiceRequest;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.library.ReadingStatusOrderType;
 import lombok.Builder;
@@ -37,5 +37,4 @@ public class UserReadingStatusGetAllRequest {
                 .readingStatus(ReadingStatus.fromName(status))
                 .build();
     }
-
 }

--- a/src/main/java/com/jisungin/api/rating/RatingController.java
+++ b/src/main/java/com/jisungin/api/rating/RatingController.java
@@ -3,43 +3,55 @@ package com.jisungin.api.rating;
 import com.jisungin.api.ApiResponse;
 import com.jisungin.api.rating.request.RatingCreateRequest;
 import com.jisungin.api.rating.request.RatingUpdateRequest;
+import com.jisungin.api.rating.request.UserRatingGetAllRequest;
 import com.jisungin.api.support.Auth;
 import com.jisungin.api.support.GuestOrAuth;
+import com.jisungin.application.PageResponse;
 import com.jisungin.application.rating.RatingService;
 import com.jisungin.application.rating.response.RatingCreateResponse;
 import com.jisungin.application.rating.response.RatingGetOneResponse;
+import com.jisungin.application.rating.response.RatingGetResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/v1/ratings")
+@RequestMapping("/v1")
 @RequiredArgsConstructor
 @RestController
 public class RatingController {
 
     private final RatingService ratingService;
 
-    @PostMapping
+    @PostMapping("/ratings")
     public ApiResponse<RatingCreateResponse> createRating(@Auth Long userId, @Valid @RequestBody RatingCreateRequest request) {
         return ApiResponse.ok(ratingService.creatingRating(userId, request.toServiceRequest()));
     }
 
-    @GetMapping
+    @GetMapping("/ratings")
     public ApiResponse<RatingGetOneResponse> getRating(@GuestOrAuth Long userId, @RequestParam String isbn) {
         return ApiResponse.ok(ratingService.getRating(userId, isbn));
     }
 
-    @PatchMapping("/{ratingId}")
+    @PatchMapping("/ratings/{ratingId}")
     public ApiResponse<Void> updateRating(
             @Auth Long userId, @PathVariable Long ratingId, @Valid @RequestBody RatingUpdateRequest request) {
         ratingService.updateRating(userId, ratingId, request.toServiceRequest());
         return ApiResponse.ok();
     }
 
-    @DeleteMapping("/{ratingId}")
+    @DeleteMapping("/ratings/{ratingId}")
     public ApiResponse<Void> deleteRating(@Auth Long userId, @PathVariable Long ratingId) {
         ratingService.deleteRating(userId, ratingId);
         return ApiResponse.ok();
     }
 
+    @GetMapping("/users/ratings")
+    public ApiResponse<PageResponse<RatingGetResponse>> getUserRatings(
+            @ModelAttribute UserRatingGetAllRequest request,
+            @Auth Long userId
+    ) {
+        PageResponse<RatingGetResponse> response = ratingService.getUserRatings(userId, request.toService());
+
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/com/jisungin/api/rating/request/UserRatingGetAllRequest.java
+++ b/src/main/java/com/jisungin/api/rating/request/UserRatingGetAllRequest.java
@@ -1,6 +1,6 @@
-package com.jisungin.api.user.request;
+package com.jisungin.api.rating.request;
 
-import com.jisungin.application.user.request.UserRatingGetAllServiceRequest;
+import com.jisungin.application.rating.request.UserRatingGetAllServiceRequest;
 import com.jisungin.domain.review.RatingOrderType;
 import lombok.*;
 
@@ -33,5 +33,4 @@ public class UserRatingGetAllRequest {
                 .rating(rating)
                 .build();
     }
-
 }

--- a/src/main/java/com/jisungin/api/review/ReviewController.java
+++ b/src/main/java/com/jisungin/api/review/ReviewController.java
@@ -1,12 +1,13 @@
 package com.jisungin.api.review;
 
 import com.jisungin.api.ApiResponse;
-import com.jisungin.api.support.Auth;
+import com.jisungin.api.review.request.ReviewContentGetAllRequest;
 import com.jisungin.api.review.request.ReviewCreateRequest;
-import com.jisungin.api.support.GuestOrAuth;
+import com.jisungin.api.support.Auth;
 import com.jisungin.application.OffsetLimit;
 import com.jisungin.application.SliceResponse;
 import com.jisungin.application.review.ReviewService;
+import com.jisungin.application.review.response.ReviewContentGetAllResponse;
 import com.jisungin.application.review.response.ReviewWithRatingResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -47,4 +48,13 @@ public class ReviewController {
         return ApiResponse.ok();
     }
 
+    @GetMapping("/users/reviews")
+    public ApiResponse<ReviewContentGetAllResponse> getReviewContents(
+            @ModelAttribute ReviewContentGetAllRequest request,
+            @Auth Long userId
+    ) {
+        ReviewContentGetAllResponse response = reviewService.getReviewContents(userId, request.toService());
+
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/com/jisungin/api/review/request/ReviewContentGetAllRequest.java
+++ b/src/main/java/com/jisungin/api/review/request/ReviewContentGetAllRequest.java
@@ -1,6 +1,6 @@
-package com.jisungin.api.user.request;
+package com.jisungin.api.review.request;
 
-import com.jisungin.application.user.request.ReviewContentGetAllServiceRequest;
+import com.jisungin.application.review.request.ReviewContentGetAllServiceRequest;
 import com.jisungin.domain.review.RatingOrderType;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,5 +32,4 @@ public class ReviewContentGetAllRequest {
                 .orderType(RatingOrderType.fromName(order))
                 .build();
     }
-
 }

--- a/src/main/java/com/jisungin/api/user/UserController.java
+++ b/src/main/java/com/jisungin/api/user/UserController.java
@@ -2,18 +2,10 @@ package com.jisungin.api.user;
 
 import com.jisungin.api.ApiResponse;
 import com.jisungin.api.support.Auth;
-import com.jisungin.api.user.request.ReviewContentGetAllRequest;
-import com.jisungin.api.user.request.UserRatingGetAllRequest;
-import com.jisungin.api.user.request.UserReadingStatusGetAllRequest;
-import com.jisungin.application.PageResponse;
-import com.jisungin.application.rating.response.RatingGetResponse;
-import com.jisungin.application.review.response.ReviewContentGetAllResponse;
 import com.jisungin.application.user.UserService;
 import com.jisungin.application.user.response.UserInfoResponse;
-import com.jisungin.application.library.response.UserReadingStatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,43 +16,9 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/ratings")
-    public ApiResponse<PageResponse<RatingGetResponse>> getUserRatings(
-            @ModelAttribute UserRatingGetAllRequest request,
-            @Auth Long userId
-    ) {
-        PageResponse<RatingGetResponse> response = userService.getUserRatings(
-                userId, request.toService());
-
-        return ApiResponse.ok(response);
-    }
-
-    @GetMapping("/reviews")
-    public ApiResponse<ReviewContentGetAllResponse> getReviewContents(
-            @ModelAttribute ReviewContentGetAllRequest request,
-            @Auth Long userId
-    ) {
-        ReviewContentGetAllResponse response = userService.getReviewContents(
-                userId, request.toService());
-
-        return ApiResponse.ok(response);
-    }
-
-    @GetMapping("/statuses")
-    public ApiResponse<PageResponse<UserReadingStatusResponse>> getReadingStatuses(
-            @ModelAttribute UserReadingStatusGetAllRequest request,
-            @Auth Long userId
-    ) {
-        PageResponse<UserReadingStatusResponse> response = userService
-                .getUserReadingStatuses(userId, request.toService());
-
-        return ApiResponse.ok(response);
-    }
-
     @GetMapping("/me")
     public ApiResponse<UserInfoResponse> getUserInfo(@Auth Long userId) {
         UserInfoResponse userInfo = userService.getUserInfo(userId);
         return ApiResponse.ok(userInfo);
     }
-
 }

--- a/src/main/java/com/jisungin/application/library/LibraryService.java
+++ b/src/main/java/com/jisungin/application/library/LibraryService.java
@@ -1,8 +1,11 @@
 package com.jisungin.application.library;
 
+import com.jisungin.application.PageResponse;
 import com.jisungin.application.library.request.LibraryCreateServiceRequest;
 import com.jisungin.application.library.request.LibraryEditServiceRequest;
 import com.jisungin.application.library.response.LibraryResponse;
+import com.jisungin.application.library.response.UserReadingStatusResponse;
+import com.jisungin.application.library.request.UserReadingStatusGetAllServiceRequest;
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
@@ -12,11 +15,14 @@ import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
 import com.jisungin.exception.BusinessException;
 import com.jisungin.exception.ErrorCode;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.jisungin.exception.ErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -89,4 +95,12 @@ public class LibraryService {
         libraryRepository.deleteById(library.getId());
     }
 
+    public PageResponse<UserReadingStatusResponse> getUserReadingStatuses(
+            Long userId, UserReadingStatusGetAllServiceRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        return libraryRepository.findAllReadingStatusOrderBy(
+                user.getId(), request.getReadingStatus(), request.getOrderType(), request.getSize(), request.getOffset());
+    }
 }

--- a/src/main/java/com/jisungin/application/library/request/UserReadingStatusGetAllServiceRequest.java
+++ b/src/main/java/com/jisungin/application/library/request/UserReadingStatusGetAllServiceRequest.java
@@ -1,4 +1,4 @@
-package com.jisungin.application.user.request;
+package com.jisungin.application.library.request;
 
 import com.jisungin.domain.ReadingStatus;
 import com.jisungin.domain.library.ReadingStatusOrderType;
@@ -35,5 +35,4 @@ public class UserReadingStatusGetAllServiceRequest {
     public int getOffset() {
         return (max(1, page) - 1) * min(size, MAX_SIZE);
     }
-
 }

--- a/src/main/java/com/jisungin/application/rating/RatingService.java
+++ b/src/main/java/com/jisungin/application/rating/RatingService.java
@@ -1,9 +1,12 @@
 package com.jisungin.application.rating;
 
+import com.jisungin.application.PageResponse;
 import com.jisungin.application.rating.request.RatingCreateServiceRequest;
 import com.jisungin.application.rating.request.RatingUpdateServiceRequest;
 import com.jisungin.application.rating.response.RatingCreateResponse;
 import com.jisungin.application.rating.response.RatingGetOneResponse;
+import com.jisungin.application.rating.response.RatingGetResponse;
+import com.jisungin.application.rating.request.UserRatingGetAllServiceRequest;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
 import com.jisungin.domain.rating.Rating;
@@ -16,7 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.jisungin.exception.ErrorCode.*;
+import static com.jisungin.exception.ErrorCode.RATING_ALREADY_EXIST;
+import static com.jisungin.exception.ErrorCode.USER_NOT_FOUND;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -88,4 +92,11 @@ public class RatingService {
         ratingRepository.deleteById(ratingId);
     }
 
+    public PageResponse<RatingGetResponse> getUserRatings(Long userId, UserRatingGetAllServiceRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        return ratingRepository.getAllRatingOrderBy(
+                user.getId(), request.getOrderType(), request.getRating(), request.getSize(), request.getOffset());
+    }
 }

--- a/src/main/java/com/jisungin/application/rating/request/UserRatingGetAllServiceRequest.java
+++ b/src/main/java/com/jisungin/application/rating/request/UserRatingGetAllServiceRequest.java
@@ -1,4 +1,4 @@
-package com.jisungin.application.user.request;
+package com.jisungin.application.rating.request;
 
 import com.jisungin.domain.review.RatingOrderType;
 import lombok.Builder;
@@ -32,5 +32,4 @@ public class UserRatingGetAllServiceRequest {
     public int getOffset() {
         return (max(1, page) - 1) * min(size, MAX_SIZE);
     }
-
 }

--- a/src/main/java/com/jisungin/application/review/request/ReviewContentGetAllServiceRequest.java
+++ b/src/main/java/com/jisungin/application/review/request/ReviewContentGetAllServiceRequest.java
@@ -1,4 +1,4 @@
-package com.jisungin.application.user.request;
+package com.jisungin.application.review.request;
 
 import com.jisungin.domain.review.RatingOrderType;
 import lombok.Builder;
@@ -30,5 +30,4 @@ public class ReviewContentGetAllServiceRequest {
     public int getOffset() {
         return (max(1, page) - 1) * min(size, MAX_SIZE);
     }
-
 }

--- a/src/main/java/com/jisungin/application/user/UserService.java
+++ b/src/main/java/com/jisungin/application/user/UserService.java
@@ -1,28 +1,14 @@
 package com.jisungin.application.user;
 
-import com.jisungin.application.PageResponse;
-import com.jisungin.application.rating.response.RatingGetResponse;
-import com.jisungin.application.review.response.ReviewContentGetAllResponse;
-import com.jisungin.application.review.response.ReviewContentResponse;
-import com.jisungin.application.user.request.ReviewContentGetAllServiceRequest;
-import com.jisungin.application.user.request.UserRatingGetAllServiceRequest;
-import com.jisungin.application.user.request.UserReadingStatusGetAllServiceRequest;
 import com.jisungin.application.user.response.UserInfoResponse;
-import com.jisungin.application.library.response.UserReadingStatusResponse;
-import com.jisungin.domain.rating.repository.RatingRepository;
-import com.jisungin.domain.review.repository.ReviewRepository;
-import com.jisungin.domain.reviewlike.repository.ReviewLikeRepository;
 import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
-import com.jisungin.domain.library.repository.LibraryRepository;
 import com.jisungin.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static com.jisungin.exception.ErrorCode.*;
+import static com.jisungin.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,52 +17,10 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    private final ReviewRepository reviewRepository;
-
-    private final RatingRepository ratingRepository;
-
-    private final ReviewLikeRepository reviewLikeRepository;
-
-    private final LibraryRepository libraryRepository;
-
-    public PageResponse<RatingGetResponse> getUserRatings(Long userId, UserRatingGetAllServiceRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-
-        return ratingRepository.getAllRatingOrderBy(
-                user.getId(), request.getOrderType(), request.getRating(), request.getSize(), request.getOffset());
-    }
-
-    public ReviewContentGetAllResponse getReviewContents(Long userId, ReviewContentGetAllServiceRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-
-        PageResponse<ReviewContentResponse> reviewContents = reviewRepository.findAllReviewContentOrderBy(
-                user.getId(), request.getOrderType(), request.getSize(), request.getOffset());
-
-        List<Long> reviewIds = reviewContents.getQueryResponse().stream()
-                .map(ReviewContentResponse::getReviewId)
-                .toList();
-
-        List<Long> likeReviewIds = reviewLikeRepository.findLikeReviewByReviewId(userId, reviewIds);
-
-        return ReviewContentGetAllResponse.of(reviewContents, likeReviewIds);
-    }
-
-    public PageResponse<UserReadingStatusResponse> getUserReadingStatuses(
-            Long userId, UserReadingStatusGetAllServiceRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-
-        return libraryRepository.findAllReadingStatusOrderBy(
-                user.getId(), request.getReadingStatus(), request.getOrderType(), request.getSize(), request.getOffset());
-    }
-
     public UserInfoResponse getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
         return UserInfoResponse.of(user.getId(), user.getName(), user.getProfileImage());
     }
-
 }

--- a/src/main/java/com/jisungin/domain/reviewlike/ReviewLike.java
+++ b/src/main/java/com/jisungin/domain/reviewlike/ReviewLike.java
@@ -3,12 +3,17 @@ package com.jisungin.domain.reviewlike;
 import com.jisungin.domain.review.Review;
 import com.jisungin.domain.user.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@ToString
+@Table(name = "review_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "review_id"})
+})
 public class ReviewLike {
 
     @Id
@@ -36,5 +41,4 @@ public class ReviewLike {
                 .review(review)
                 .build();
     }
-
 }

--- a/src/test/java/com/jisungin/ControllerTestSupport.java
+++ b/src/test/java/com/jisungin/ControllerTestSupport.java
@@ -5,6 +5,7 @@ import com.jisungin.api.book.BookController;
 import com.jisungin.api.comment.CommentController;
 import com.jisungin.api.commentlike.CommentLikeController;
 import com.jisungin.api.image.ImageController;
+import com.jisungin.api.rating.RatingController;
 import com.jisungin.api.review.ReviewController;
 import com.jisungin.api.reviewlike.ReviewLikeController;
 import com.jisungin.api.search.SearchController;
@@ -18,6 +19,7 @@ import com.jisungin.application.book.BookService;
 import com.jisungin.application.comment.CommentService;
 import com.jisungin.application.commentlike.CommentLikeService;
 import com.jisungin.application.image.ImageService;
+import com.jisungin.application.rating.RatingService;
 import com.jisungin.application.review.ReviewService;
 import com.jisungin.application.reviewlike.ReviewLikeService;
 import com.jisungin.application.search.SearchService;
@@ -47,7 +49,8 @@ import org.springframework.test.web.servlet.MockMvc;
         ReviewLikeController.class,
         ImageController.class,
         SearchController.class,
-        LibraryController.class
+        LibraryController.class,
+        RatingController.class
 },
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
@@ -61,6 +64,9 @@ public abstract class ControllerTestSupport {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected RatingService ratingService;
 
     @MockBean
     protected TalkRoomService talkRoomService;
@@ -112,6 +118,4 @@ public abstract class ControllerTestSupport {
                 .id(1L)
                 .build();
     }
-
-
 }

--- a/src/test/java/com/jisungin/ServiceTestSupport.java
+++ b/src/test/java/com/jisungin/ServiceTestSupport.java
@@ -13,5 +13,4 @@ public abstract class ServiceTestSupport {
 
     @MockBean
     protected ClientRegistrationRepository clientRegistrationRepository;
-
 }

--- a/src/test/java/com/jisungin/api/library/LibraryControllerTest.java
+++ b/src/test/java/com/jisungin/api/library/LibraryControllerTest.java
@@ -1,19 +1,16 @@
 package com.jisungin.api.library;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.jisungin.ControllerTestSupport;
 import com.jisungin.api.library.request.LibraryCreateRequest;
 import com.jisungin.api.library.request.LibraryEditRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class LibraryControllerTest extends ControllerTestSupport {
 
@@ -172,4 +169,19 @@ public class LibraryControllerTest extends ControllerTestSupport {
                 .andDo(print());
     }
 
+    @DisplayName("사용자의 독서 상태를 조회한다.")
+    @Test
+    void getReadingStatuses() throws Exception {
+        //given
+        //when //then
+        mockMvc.perform(get("/v1/users/libraries/statuses?page=1&size=4&order=dictionary&status=want")
+                        .contentType(APPLICATION_JSON)
+                        .session(mockHttpSession)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/jisungin/api/rating/RatingControllerTest.java
+++ b/src/test/java/com/jisungin/api/rating/RatingControllerTest.java
@@ -1,0 +1,30 @@
+package com.jisungin.api.rating;
+
+import com.jisungin.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RatingControllerTest extends ControllerTestSupport {
+
+    @DisplayName("사용자의 모든 별점을 조회한다.")
+    @Test
+    void getUserRatings() throws Exception {
+        //given
+        //when //then
+        mockMvc.perform(get("/v1/users/ratings?page=1&size=4&order=rating_asc&rating=")
+                        .contentType(APPLICATION_JSON)
+                        .session(mockHttpSession)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/jisungin/api/review/ReviewControllerTest.java
+++ b/src/test/java/com/jisungin/api/review/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.jisungin.api.review;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -131,4 +132,19 @@ class ReviewControllerTest extends ControllerTestSupport {
                 .andDo(print());
     }
 
+    @DisplayName("사용자의 모든 리뷰 내용을 조회한다.")
+    @Test
+    void getReviewContents() throws Exception {
+        //given
+        //when //then
+        mockMvc.perform(get("/v1/users/reviews?page=1&size=4&order=rating_avg_desc")
+                        .contentType(APPLICATION_JSON)
+                        .session(mockHttpSession)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/jisungin/api/user/UserControllerTest.java
+++ b/src/test/java/com/jisungin/api/user/UserControllerTest.java
@@ -11,54 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class UserControllerTest extends ControllerTestSupport {
 
-    @DisplayName("사용자의 모든 리뷰 별점을 조회한다.")
-    @Test
-    void getUserRatings() throws Exception {
-        //given
-        //when //then
-        mockMvc.perform(get("/v1/users/ratings?page=1&size=4&order=rating_asc&rating=")
-                        .contentType(APPLICATION_JSON)
-                        .session(mockHttpSession)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print());
-    }
-
-    @DisplayName("사용자의 모든 리뷰 내용을 조회한다.")
-    @Test
-    void getReviewContents() throws Exception {
-        //given
-        //when //then
-        mockMvc.perform(get("/v1/users/reviews?page=1&size=4&order=rating_avg_desc")
-                        .contentType(APPLICATION_JSON)
-                        .session(mockHttpSession)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print());
-    }
-
-    @DisplayName("사용자의 독서 상태를 조회한다.")
-    @Test
-    void getReadingStatuses() throws Exception {
-        //given
-        //when //then
-        mockMvc.perform(get("/v1/users/statuses?page=1&size=4&order=dictionary&status=want")
-                        .contentType(APPLICATION_JSON)
-                        .session(mockHttpSession)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print());
-    }
-
     @DisplayName("사용자 정보를 조회한다.")
     @Test
     void getUserInfo() throws Exception {
@@ -74,5 +26,4 @@ class UserControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("OK"))
                 .andDo(print());
     }
-
 }

--- a/src/test/java/com/jisungin/application/review/ReviewServiceTest.java
+++ b/src/test/java/com/jisungin/application/review/ReviewServiceTest.java
@@ -1,15 +1,16 @@
 package com.jisungin.application.review;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.jisungin.ServiceTestSupport;
 import com.jisungin.application.OffsetLimit;
 import com.jisungin.application.SliceResponse;
 import com.jisungin.application.review.request.ReviewCreateServiceRequest;
+import com.jisungin.application.review.response.ReviewContentGetAllResponse;
 import com.jisungin.application.review.response.ReviewWithRatingResponse;
+import com.jisungin.application.review.request.ReviewContentGetAllServiceRequest;
 import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
+import com.jisungin.domain.rating.Rating;
+import com.jisungin.domain.rating.repository.RatingRepository;
 import com.jisungin.domain.review.Review;
 import com.jisungin.domain.review.repository.ReviewRepository;
 import com.jisungin.domain.reviewlike.ReviewLike;
@@ -19,13 +20,20 @@ import com.jisungin.domain.user.OauthType;
 import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
 import com.jisungin.exception.BusinessException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.jisungin.domain.review.RatingOrderType.RATING_AVG_ASC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 
 class ReviewServiceTest extends ServiceTestSupport {
 
@@ -34,6 +42,9 @@ class ReviewServiceTest extends ServiceTestSupport {
 
     @Autowired
     private ReviewLikeRepository reviewLikeRepository;
+
+    @Autowired
+    private RatingRepository ratingRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -46,6 +57,7 @@ class ReviewServiceTest extends ServiceTestSupport {
 
     @AfterEach
     void tearDown() {
+        ratingRepository.deleteAllInBatch();
         reviewLikeRepository.deleteAllInBatch();
         reviewRepository.deleteAllInBatch();
         bookRepository.deleteAllInBatch();
@@ -211,6 +223,66 @@ class ReviewServiceTest extends ServiceTestSupport {
                 .hasMessage("권한이 없는 사용자입니다.");
     }
 
+    @DisplayName("사용자의 모든 리뷰 내용을 별점 오름차 순으로 가져온다.")
+    @Test
+    void getReviewContents() {
+        //given
+        User user1 = userRepository.save(createUser("1"));
+        User user2 = userRepository.save(createUser("2"));
+        List<Book> books = bookRepository.saveAll(createBooks());
+        List<Review> reviews = reviewRepository.saveAll(createReviews(user1, books));
+        List<Rating> ratings1 = ratingRepository.saveAll(createRatings(user1, books));
+        List<Rating> ratings2 = ratingRepository.saveAll(createRatings(user2, books));
+        List<ReviewLike> reviewLikesWithUser1 = reviewLikeRepository.saveAll(createReviewLikes(user1, reviews));
+        List<ReviewLike> reviewLikesWithUser2 = reviewLikeRepository.saveAll(createReviewLikes(user2, reviews));
+
+        // 1번째부터 4번째 데이터를 요청, 별점 1.0인 리뷰 내용이 4개 나와야 함
+        ReviewContentGetAllServiceRequest request = ReviewContentGetAllServiceRequest.builder()
+                .page(1)
+                .size(4)
+                .orderType(RATING_AVG_ASC)
+                .build();
+
+        //when
+        ReviewContentGetAllResponse result = reviewService.getReviewContents(user1.getId(), request);
+
+        //then
+        assertThat(result.getReviewContents().getTotalCount()).isEqualTo(20);
+        assertThat(result.getReviewContents().getQueryResponse()).hasSize(4)
+                .extracting(
+                        "userImage", "userName", "rating", "content", "isbn", "title", "bookImage")
+                .containsExactly(
+                        tuple("image", "김도형", 1.0, "리뷰 내용1", "1", "제목1", "bookImage"),
+                        tuple("image", "김도형", 1.0, "리뷰 내용11", "11", "제목11", "bookImage"),
+                        tuple("image", "김도형", 1.0, "리뷰 내용16", "16", "제목16", "bookImage"),
+                        tuple("image", "김도형", 1.0, "리뷰 내용6", "6", "제목6", "bookImage")
+                );
+        assertThat(result.getUserLikes()).hasSize(4);
+    }
+
+    private static List<Review> createReviews(User user, List<Book> books) {
+        return IntStream.range(0, 20)
+                .mapToObj(i -> {
+                    double rating = i % 5 + 1.0; // 1.0, 2.0, 3.0, 4.0, 5.0이 순환되도록 설정
+                    return createReview(user, books.get(i), rating); // Review 객체 생성
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static Review createReview(User user, Book book, Double rating) {
+        return Review.builder()
+                .user(user)
+                .book(book)
+                .content("리뷰 내용" + book.getIsbn())
+                .build();
+    }
+
+    private static List<ReviewLike> createReviewLikes(User user, List<Review> reviews) {
+        return reviews.stream()
+                .map(review -> createReviewLike(user, review))
+                .toList();
+    }
+
     private static ReviewLike createReviewLike(User user, Review review) {
         return ReviewLike.builder()
                 .user(user)
@@ -270,4 +342,39 @@ class ReviewServiceTest extends ServiceTestSupport {
                 .build();
     }
 
+    private static List<Book> createBooks() {
+        return IntStream.rangeClosed(1, 20)
+                .mapToObj(i -> createBook(
+                        "제목" + String.valueOf(i), "내용" + String.valueOf(i), String.valueOf(i)))
+                .collect(Collectors.toList());
+    }
+
+    private static Book createBook(String title, String content, String isbn) {
+        return Book.builder()
+                .title(title)
+                .content(content)
+                .authors("김도형")
+                .isbn(isbn)
+                .publisher("지성인")
+                .dateTime(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .imageUrl("bookImage")
+                .build();
+    }
+
+    private static List<Rating> createRatings(User user, List<Book> books) {
+        return IntStream.range(0, 20)
+                .mapToObj(i -> {
+                    double rating = i % 5 + 1.0;
+                    return createRating(user, books.get(i), rating);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static Rating createRating(User user, Book book, Double rating) {
+        return Rating.builder()
+                .user(user)
+                .book(book)
+                .rating(rating)
+                .build();
+    }
 }

--- a/src/test/java/com/jisungin/application/user/UserServiceTest.java
+++ b/src/test/java/com/jisungin/application/user/UserServiceTest.java
@@ -1,49 +1,21 @@
 package com.jisungin.application.user;
 
-import static com.jisungin.domain.ReadingStatus.PAUSE;
-import static com.jisungin.domain.ReadingStatus.READ;
-import static com.jisungin.domain.ReadingStatus.READING;
-import static com.jisungin.domain.ReadingStatus.STOP;
-import static com.jisungin.domain.ReadingStatus.WANT;
-import static com.jisungin.domain.library.ReadingStatusOrderType.DICTIONARY;
-import static com.jisungin.domain.review.RatingOrderType.RATING_ASC;
-import static com.jisungin.domain.review.RatingOrderType.RATING_AVG_ASC;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
-
 import com.jisungin.ServiceTestSupport;
-import com.jisungin.application.PageResponse;
-import com.jisungin.application.library.response.UserReadingStatusResponse;
-import com.jisungin.application.rating.response.RatingGetResponse;
-import com.jisungin.application.review.response.ReviewContentGetAllResponse;
-import com.jisungin.application.user.request.ReviewContentGetAllServiceRequest;
-import com.jisungin.application.user.request.UserRatingGetAllServiceRequest;
-import com.jisungin.application.user.request.UserReadingStatusGetAllServiceRequest;
 import com.jisungin.application.user.response.UserInfoResponse;
-import com.jisungin.domain.ReadingStatus;
-import com.jisungin.domain.book.Book;
 import com.jisungin.domain.book.repository.BookRepository;
-import com.jisungin.domain.library.Library;
-import com.jisungin.domain.library.repository.LibraryRepository;
-import com.jisungin.domain.rating.Rating;
 import com.jisungin.domain.rating.repository.RatingRepository;
-import com.jisungin.domain.review.Review;
 import com.jisungin.domain.review.repository.ReviewRepository;
-import com.jisungin.domain.reviewlike.ReviewLike;
 import com.jisungin.domain.reviewlike.repository.ReviewLikeRepository;
 import com.jisungin.domain.user.OauthId;
 import com.jisungin.domain.user.OauthType;
 import com.jisungin.domain.user.User;
 import com.jisungin.domain.user.repository.UserRepository;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class UserServiceTest extends ServiceTestSupport {
 
@@ -63,121 +35,16 @@ class UserServiceTest extends ServiceTestSupport {
     private ReviewLikeRepository reviewLikeRepository;
 
     @Autowired
-    private LibraryRepository libraryRepository;
-
-    @Autowired
     private UserService userService;
 
     @AfterEach
     void tearDown() {
-        libraryRepository.deleteAllInBatch();
         reviewLikeRepository.deleteAllInBatch();
         reviewRepository.deleteAllInBatch();
         ratingRepository.deleteAllInBatch();
         bookRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
-
-    @DisplayName("사용자의 모든 리뷰 별점을 오름차 순으로 가져온다.")
-    @Test
-    void getUserRatings() {
-        //given
-        User user = userRepository.save(createUser("1"));
-        List<Book> books = bookRepository.saveAll(createBooks());
-        List<Rating> ratings = ratingRepository.saveAll(createRatings(user, books));
-
-        // 5번째부터 8번째 데이터를 요청, 별점 2.0이 4개가 나와야 함
-        UserRatingGetAllServiceRequest request = UserRatingGetAllServiceRequest.builder()
-                .page(2)
-                .size(4)
-                .orderType(RATING_ASC)
-                .build();
-
-        //when
-        PageResponse<RatingGetResponse> result = userService.getUserRatings(user.getId(), request);
-
-        //then
-        assertThat(result.getTotalCount()).isEqualTo(20);
-        assertThat(result.getQueryResponse()).hasSize(4)
-                .extracting("isbn", "title", "image", "rating")
-                .containsExactly(
-                        tuple("12", "제목12", "bookImage", 2.0),
-                        tuple("17", "제목17", "bookImage", 2.0),
-                        tuple("2", "제목2", "bookImage", 2.0),
-                        tuple("7", "제목7", "bookImage", 2.0)
-                );
-    }
-
-    @DisplayName("사용자의 모든 리뷰 내용을 별점 오름차 순으로 가져온다.")
-    @Test
-    void getReviewContents() {
-        //given
-        User user1 = userRepository.save(createUser("1"));
-        User user2 = userRepository.save(createUser("2"));
-        List<Book> books = bookRepository.saveAll(createBooks());
-        List<Review> reviews = reviewRepository.saveAll(createReviews(user1, books));
-        List<Rating> ratings1 = ratingRepository.saveAll(createRatings(user1, books));
-        List<Rating> ratings2 = ratingRepository.saveAll(createRatings(user2, books));
-        List<ReviewLike> reviewLikesWithUser1 = reviewLikeRepository.saveAll(createReviewLikes(user1, reviews));
-        List<ReviewLike> reviewLikesWithUser2 = reviewLikeRepository.saveAll(createReviewLikes(user2, reviews));
-
-        // 1번째부터 4번째 데이터를 요청, 별점 1.0인 리뷰 내용이 4개 나와야 함
-        ReviewContentGetAllServiceRequest request = ReviewContentGetAllServiceRequest.builder()
-                .page(1)
-                .size(4)
-                .orderType(RATING_AVG_ASC)
-                .build();
-
-        //when
-        ReviewContentGetAllResponse result = userService.getReviewContents(user1.getId(), request);
-
-        //then
-        assertThat(result.getReviewContents().getTotalCount()).isEqualTo(20);
-        assertThat(result.getReviewContents().getQueryResponse()).hasSize(4)
-                .extracting(
-                        "userImage", "userName", "rating", "content", "isbn", "title", "bookImage")
-                .containsExactly(
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용1", "1", "제목1", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용11", "11", "제목11", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용16", "16", "제목16", "bookImage"),
-                        tuple("userImage", "김도형", 1.0, "리뷰 내용6", "6", "제목6", "bookImage")
-                );
-        assertThat(result.getUserLikes()).hasSize(4);
-    }
-
-    @DisplayName("사용자의 독서 상태가 읽고 싶은 책을 가져온다.")
-    @Test
-    void getReadingStatuses() {
-        //given
-        User user1 = userRepository.save(createUser("1"));
-        User user2 = userRepository.save(createUser("2"));
-        List<Book> books = bookRepository.saveAll(createBooks());
-        List<Rating> ratings1 = ratingRepository.saveAll(createRatings(user1, books));
-        List<Library> userLibraries = libraryRepository.saveAll(createUserLibraries(user1, books));
-
-        // 읽고 싶은 상태인 책을 사전 순으로 정렬하고 1페이지를 가져온다.
-        UserReadingStatusGetAllServiceRequest request = UserReadingStatusGetAllServiceRequest.builder()
-                .page(1)
-                .size(4)
-                .orderType(DICTIONARY)
-                .readingStatus(WANT)
-                .build();
-
-        //when
-        PageResponse<UserReadingStatusResponse> result = userService.getUserReadingStatuses(user1.getId(), request);
-
-        //then
-        assertThat(result.getTotalCount()).isEqualTo(4);
-        assertThat(result.getQueryResponse()).hasSize(4)
-                .extracting("bookImage", "bookTitle", "ratingAvg")
-                .containsExactly(
-                        tuple("bookImage", "제목1", 1.0),
-                        tuple("bookImage", "제목11", 1.0),
-                        tuple("bookImage", "제목16", 1.0),
-                        tuple("bookImage", "제목6", 1.0)
-                );
-    }
-
 
     @DisplayName("해당 사용자 정보를 조회한다.")
     @Test
@@ -194,56 +61,6 @@ class UserServiceTest extends ServiceTestSupport {
         assertThat(result.getUserImage()).isEqualTo(user.getProfileImage());
     }
 
-
-    private static List<Book> createBooks() {
-        return IntStream.rangeClosed(1, 20)
-                .mapToObj(i -> createBook(
-                        "제목" + String.valueOf(i), "내용" + String.valueOf(i), String.valueOf(i)))
-                .collect(Collectors.toList());
-    }
-
-    private static Book createBook(String title, String content, String isbn) {
-        return Book.builder()
-                .title(title)
-                .content(content)
-                .authors("김도형")
-                .isbn(isbn)
-                .publisher("지성인")
-                .dateTime(LocalDateTime.of(2024, 1, 1, 0, 0))
-                .imageUrl("bookImage")
-                .build();
-    }
-
-    private static List<Review> createReviews(User user, List<Book> books) {
-        return IntStream.range(0, 20)
-                .mapToObj(i -> {
-                    double rating = i % 5 + 1.0; // 1.0, 2.0, 3.0, 4.0, 5.0이 순환되도록 설정
-                    return createReview(user, books.get(i), rating); // Review 객체 생성
-                })
-                .collect(Collectors.toList());
-    }
-
-    private static Review createReview(User user, Book book, Double rating) {
-        return Review.builder()
-                .user(user)
-                .book(book)
-                .content("리뷰 내용" + book.getIsbn())
-                .build();
-    }
-
-    private static List<ReviewLike> createReviewLikes(User user, List<Review> reviews) {
-        return reviews.stream()
-                .map(review -> createReviewLike(user, review))
-                .toList();
-    }
-
-    private static ReviewLike createReviewLike(User user, Review review) {
-        return ReviewLike.builder()
-                .user(user)
-                .review(review)
-                .build();
-    }
-
     private static User createUser(String oauthId) {
         return User.builder()
                 .name("김도형")
@@ -256,44 +73,4 @@ class UserServiceTest extends ServiceTestSupport {
                 )
                 .build();
     }
-
-    private static List<Library> createUserLibraries(User user, List<Book> books) {
-        List<Library> userLibraries = new ArrayList<>();
-        List<ReadingStatus> statuses = List.of(WANT, READING, READ, PAUSE, STOP);
-
-        IntStream.rangeClosed(1, 20)
-                .forEach(i -> {
-                    ReadingStatus readingStatus = statuses.get((i - 1) % statuses.size());
-                    Library library = createUserLibrary(user, books.get(i - 1), readingStatus);
-                    userLibraries.add(library);
-                });
-
-        return userLibraries;
-    }
-
-    private static Library createUserLibrary(User user, Book book, ReadingStatus readingStatus) {
-        return Library.builder()
-                .user(user)
-                .book(book)
-                .status(readingStatus)
-                .build();
-    }
-
-    private static List<Rating> createRatings(User user, List<Book> books) {
-        return IntStream.range(0, 20)
-                .mapToObj(i -> {
-                    double rating = i % 5 + 1.0;
-                    return createRating(user, books.get(i), rating);
-                })
-                .collect(Collectors.toList());
-    }
-
-    private static Rating createRating(User user, Book book, Double rating) {
-        return Rating.builder()
-                .user(user)
-                .book(book)
-                .rating(rating)
-                .build();
-    }
-
 }

--- a/src/test/java/com/jisungin/docs/rating/RatingControllerDocsTest.java
+++ b/src/test/java/com/jisungin/docs/rating/RatingControllerDocsTest.java
@@ -3,25 +3,34 @@ package com.jisungin.docs.rating;
 import com.jisungin.api.rating.RatingController;
 import com.jisungin.api.rating.request.RatingCreateRequest;
 import com.jisungin.api.rating.request.RatingUpdateRequest;
+import com.jisungin.application.PageResponse;
 import com.jisungin.application.rating.RatingService;
 import com.jisungin.application.rating.request.RatingCreateServiceRequest;
 import com.jisungin.application.rating.response.RatingCreateResponse;
 import com.jisungin.application.rating.response.RatingGetOneResponse;
+import com.jisungin.application.rating.response.RatingGetResponse;
+import com.jisungin.application.rating.request.UserRatingGetAllServiceRequest;
 import com.jisungin.docs.RestDocsSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class RatingControllerDocsTest extends RestDocsSupport {
@@ -190,4 +199,83 @@ public class RatingControllerDocsTest extends RestDocsSupport {
                 ));
     }
 
+    @DisplayName("유저 별점 페이징 조회 API")
+    @Test
+    void getUserRatings() throws Exception {
+
+        List<RatingGetResponse> ratingGetAllResponse = createRatingFindAllResponse();
+
+        PageResponse<RatingGetResponse> response = PageResponse.<RatingGetResponse>builder()
+                .size(10)
+                .totalCount(10)
+                .queryResponse(ratingGetAllResponse)
+                .build();
+
+        given(ratingService.getUserRatings(anyLong(), any(UserRatingGetAllServiceRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/v1/users/ratings")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .param("order", "rating_asc")
+                        .param("rating", "")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andDo(print())
+                .andDo(document("rating/user-ratings",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page")
+                                        .description("페이지 번호"),
+                                parameterWithName("size")
+                                        .description("페이지 사이즈"),
+                                parameterWithName("order")
+                                        .description(
+                                                "정렬 기준 : date(날짜순), rating_asc(별점 오름차), rating_desc(별점 내림차), " +
+                                                        "rating_avg_asc(별점 평균 오름차), rating_avg_desc(별점 평균 내림차)"),
+                                parameterWithName("rating")
+                                        .description("해당 별점만 조회 -> 1.0, 2.5, 4.0 (전체 조회는 null로)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.queryResponse").type(JsonFieldType.ARRAY)
+                                        .description("책 목록"),
+                                fieldWithPath("data.queryResponse[].isbn").type(JsonFieldType.STRING)
+                                        .description("책 isbn"),
+                                fieldWithPath("data.queryResponse[].title").type(JsonFieldType.STRING)
+                                        .description("책 제목"),
+                                fieldWithPath("data.queryResponse[].image").type(JsonFieldType.STRING)
+                                        .description("책 표지"),
+                                fieldWithPath("data.queryResponse[].rating").type(JsonFieldType.NUMBER)
+                                        .description("책 별점"),
+                                fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER)
+                                        .description("데이터 총 개수"),
+                                fieldWithPath("data.size").type(JsonFieldType.NUMBER)
+                                        .description("해당 페이지 데이터 개수")
+                        )
+                ));
+    }
+
+    private List<RatingGetResponse> createRatingFindAllResponse() {
+        return IntStream.range(0, 10)
+                .mapToObj(i -> RatingGetResponse.builder()
+                        .isbn(String.valueOf(i))
+                        .title("책 제목" + i)
+                        .image("책 이미지" + i)
+                        .rating(i % 5.0 + 1)
+                        .build())
+                .toList();
+    }
 }

--- a/src/test/java/com/jisungin/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/jisungin/docs/user/UserControllerDocsTest.java
@@ -1,26 +1,13 @@
 package com.jisungin.docs.user;
 
 import com.jisungin.api.user.UserController;
-import com.jisungin.application.PageResponse;
-import com.jisungin.application.rating.response.RatingGetResponse;
-import com.jisungin.application.review.response.ReviewContentGetAllResponse;
-import com.jisungin.application.review.response.ReviewContentResponse;
 import com.jisungin.application.user.UserService;
-import com.jisungin.application.user.request.ReviewContentGetAllServiceRequest;
-import com.jisungin.application.user.request.UserRatingGetAllServiceRequest;
-import com.jisungin.application.user.request.UserReadingStatusGetAllServiceRequest;
 import com.jisungin.application.user.response.UserInfoResponse;
-import com.jisungin.application.library.response.UserReadingStatusResponse;
 import com.jisungin.docs.RestDocsSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -29,11 +16,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class UserControllerDocsTest extends RestDocsSupport {
@@ -43,229 +27,6 @@ public class UserControllerDocsTest extends RestDocsSupport {
     @Override
     protected Object initController() {
         return new UserController(userService);
-    }
-
-    @DisplayName("유저 별점 페이징 조회 API")
-    @Test
-    void getUserRatings() throws Exception {
-
-        List<RatingGetResponse> ratingGetAllResponse = createRatingFindAllResponse();
-
-        PageResponse<RatingGetResponse> response = PageResponse.<RatingGetResponse>builder()
-                .size(10)
-                .totalCount(10)
-                .queryResponse(ratingGetAllResponse)
-                .build();
-
-        given(userService.getUserRatings(anyLong(), any(UserRatingGetAllServiceRequest.class)))
-                .willReturn(response);
-
-        mockMvc.perform(get("/v1/users/ratings")
-                        .param("page", "1")
-                        .param("size", "10")
-                        .param("order", "rating_asc")
-                        .param("rating", "")
-                        .contentType(APPLICATION_JSON)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print())
-                .andDo(document("rating/findAll",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        queryParameters(
-                                parameterWithName("page")
-                                        .description("페이지 번호"),
-                                parameterWithName("size")
-                                        .description("페이지 사이즈"),
-                                parameterWithName("order")
-                                        .description(
-                                                "정렬 기준 : date(날짜순), rating_asc(별점 오름차), rating_desc(별점 내림차), " +
-                                                        "rating_avg_asc(별점 평균 오름차), rating_avg_desc(별점 평균 내림차)"),
-                                parameterWithName("rating")
-                                        .description("해당 별점만 조회 -> 1.0, 2.5, 4.0 (전체 조회는 null로)").optional()
-                        ),
-                        responseFields(
-                                fieldWithPath("code").type(JsonFieldType.NUMBER)
-                                        .description("코드"),
-                                fieldWithPath("status").type(JsonFieldType.STRING)
-                                        .description("상태"),
-                                fieldWithPath("message").type(JsonFieldType.STRING)
-                                        .description("메시지"),
-                                fieldWithPath("data").type(JsonFieldType.OBJECT)
-                                        .description("응답 데이터"),
-                                fieldWithPath("data.queryResponse").type(JsonFieldType.ARRAY)
-                                        .description("책 목록"),
-                                fieldWithPath("data.queryResponse[].isbn").type(JsonFieldType.STRING)
-                                        .description("책 isbn"),
-                                fieldWithPath("data.queryResponse[].title").type(JsonFieldType.STRING)
-                                        .description("책 제목"),
-                                fieldWithPath("data.queryResponse[].image").type(JsonFieldType.STRING)
-                                        .description("책 표지"),
-                                fieldWithPath("data.queryResponse[].rating").type(JsonFieldType.NUMBER)
-                                        .description("책 별점"),
-                                fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER)
-                                        .description("데이터 총 개수"),
-                                fieldWithPath("data.size").type(JsonFieldType.NUMBER)
-                                        .description("해당 페이지 데이터 개수")
-                        )
-                ));
-    }
-
-    @DisplayName("유저 한줄평 페이징 조회 API")
-    @Test
-    void getUserReviews() throws Exception {
-        List<ReviewContentResponse> reviewGetAllResponse = createReviewFindAllResponse();
-        List<Long> likeReviewIds = createLikeReviewIds();
-
-        PageResponse<ReviewContentResponse> reviewContents = PageResponse.<ReviewContentResponse>builder()
-                .size(10)
-                .totalCount(10)
-                .queryResponse(reviewGetAllResponse)
-                .build();
-
-        given(userService.getReviewContents(anyLong(), any(ReviewContentGetAllServiceRequest.class)))
-                .willReturn(ReviewContentGetAllResponse.of(reviewContents, likeReviewIds));
-
-        mockMvc.perform(get("/v1/users/reviews")
-                        .param("page", "1")
-                        .param("size", "10")
-                        .param("order", "rating_asc")
-                        .contentType(APPLICATION_JSON)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print())
-                .andDo(document("review/findAll",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        queryParameters(
-                                parameterWithName("page")
-                                        .description("페이지 번호"),
-                                parameterWithName("size")
-                                        .description("페이지 사이즈"),
-                                parameterWithName("order")
-                                        .description(
-                                                "정렬 기준 : date(날짜순), rating_asc(별점 오름차), rating_desc(별점 내림차), " +
-                                                        "rating_avg_asc(별점 평균 오름차), rating_avg_desc(별점 평균 내림차)")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").type(JsonFieldType.NUMBER)
-                                        .description("코드"),
-                                fieldWithPath("status").type(JsonFieldType.STRING)
-                                        .description("상태"),
-                                fieldWithPath("message").type(JsonFieldType.STRING)
-                                        .description("메시지"),
-                                fieldWithPath("data").type(JsonFieldType.OBJECT)
-                                        .description("응답 데이터"),
-                                fieldWithPath("data.reviewContents").type(JsonFieldType.OBJECT)
-                                        .description("리뷰 컨텐츠"),
-                                fieldWithPath("data.reviewContents.queryResponse").type(JsonFieldType.ARRAY)
-                                        .description("리뷰 목록"),
-                                fieldWithPath("data.reviewContents.queryResponse[].reviewId").type(JsonFieldType.NUMBER)
-                                        .description("리뷰 ID"),
-                                fieldWithPath("data.reviewContents.queryResponse[].userImage").type(
-                                                JsonFieldType.STRING)
-                                        .description("유저 프로필 이미지"),
-                                fieldWithPath("data.reviewContents.queryResponse[].userName").type(JsonFieldType.STRING)
-                                        .description("유저 이름"),
-                                fieldWithPath("data.reviewContents.queryResponse[].rating").type(JsonFieldType.NUMBER)
-                                        .description("별점"),
-                                fieldWithPath("data.reviewContents.queryResponse[].content").type(JsonFieldType.STRING)
-                                        .description("리뷰 내용"),
-                                fieldWithPath("data.reviewContents.queryResponse[].isbn").type(JsonFieldType.STRING)
-                                        .description("책 ISBN"),
-                                fieldWithPath("data.reviewContents.queryResponse[].title").type(JsonFieldType.STRING)
-                                        .description("책 제목"),
-                                fieldWithPath("data.reviewContents.queryResponse[].bookImage").type(JsonFieldType.STRING)
-                                        .description("책 표지"),
-                                fieldWithPath("data.reviewContents.queryResponse[].authors").type(JsonFieldType.STRING)
-                                        .description("책 저자"),
-                                fieldWithPath("data.reviewContents.queryResponse[].publisher").type(JsonFieldType.STRING)
-                                        .description("책 출판사"),
-                                fieldWithPath("data.reviewContents.queryResponse[].likeCount").type(JsonFieldType.NUMBER)
-                                        .description("좋아요 총개수"),
-                                fieldWithPath("data.reviewContents.totalCount").type(JsonFieldType.NUMBER)
-                                        .description("총 리뷰 개수"),
-                                fieldWithPath("data.reviewContents.size").type(JsonFieldType.NUMBER)
-                                        .description("해당 페이지 리뷰 개수"),
-                                fieldWithPath("data.userLikes").type(JsonFieldType.ARRAY)
-                                        .description("유저가 좋아요한 리뷰 ID 목록")
-                        )
-                ));
-    }
-
-    @DisplayName("유저 독서 상태 페이징 조회 API")
-    @Test
-    void getReadingStatuses() throws Exception {
-        List<UserReadingStatusResponse> readingStatusesResponse = createReadingStatusResponse();
-
-        PageResponse<UserReadingStatusResponse> response = PageResponse.<UserReadingStatusResponse>builder()
-                .size(10)
-                .totalCount(10)
-                .queryResponse(readingStatusesResponse)
-                .build();
-
-        given(userService.getUserReadingStatuses(anyLong(), any(UserReadingStatusGetAllServiceRequest.class)))
-                .willReturn(response);
-
-        mockMvc.perform(get("/v1/users/statuses")
-                        .param("page", "1")
-                        .param("size", "10")
-                        .param("order", "dictionary")
-                        .param("status", "want")
-                        .contentType(APPLICATION_JSON)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andDo(print())
-                .andDo(document("library/get-status",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        queryParameters(
-                                parameterWithName("page")
-                                        .description("페이지 번호"),
-                                parameterWithName("size")
-                                        .description("페이지 사이즈"),
-                                parameterWithName("order")
-                                        .description(
-                                                "정렬 기준 : dictionary(가나다순), rating_avg_desc(평균 별점 높은 순)"),
-                                parameterWithName("status")
-                                        .description(
-                                                "선택 기준 : want(읽고 싶은), reading(읽는 중), pause(잠시 멈춤)," +
-                                                        "stop(중단), none(상관없음)")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").type(JsonFieldType.NUMBER)
-                                        .description("코드"),
-                                fieldWithPath("status").type(JsonFieldType.STRING)
-                                        .description("상태"),
-                                fieldWithPath("message").type(JsonFieldType.STRING)
-                                        .description("메시지"),
-                                fieldWithPath("data").type(JsonFieldType.OBJECT)
-                                        .description("응답 데이터"),
-                                fieldWithPath("data.queryResponse").type(JsonFieldType.ARRAY)
-                                        .description("책 목록"),
-                                fieldWithPath("data.queryResponse[].isbn").type(JsonFieldType.STRING)
-                                        .description("책 isbn"),
-                                fieldWithPath("data.queryResponse[].bookTitle").type(JsonFieldType.STRING)
-                                        .description("책 제목"),
-                                fieldWithPath("data.queryResponse[].bookImage").type(JsonFieldType.STRING)
-                                        .description("책 표지"),
-                                fieldWithPath("data.queryResponse[].ratingAvg").type(JsonFieldType.NUMBER)
-                                        .description("책 평균 별점"),
-                                fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER)
-                                        .description("데이터 총 개수"),
-                                fieldWithPath("data.size").type(JsonFieldType.NUMBER)
-                                        .description("해당 페이지 데이터 개수")
-                        )
-                ));
     }
 
     @DisplayName("유저 상세 조회 API")
@@ -305,52 +66,4 @@ public class UserControllerDocsTest extends RestDocsSupport {
                         )
                 ));
     }
-
-    private List<RatingGetResponse> createRatingFindAllResponse() {
-        return IntStream.range(0, 10)
-                .mapToObj(i -> RatingGetResponse.builder()
-                        .isbn(String.valueOf(i))
-                        .title("책 제목" + i)
-                        .image("책 이미지" + i)
-                        .rating(i % 5.0 + 1)
-                        .build())
-                .toList();
-    }
-
-    private List<ReviewContentResponse> createReviewFindAllResponse() {
-        return IntStream.range(0, 10)
-                .mapToObj(i -> ReviewContentResponse.builder()
-                        .reviewId(i + 1L)
-                        .userImage("userImage" + i)
-                        .userName("name" + i)
-                        .rating(i % 5.0 + 1)
-                        .content("content" + i)
-                        .isbn(String.valueOf(i))
-                        .title("title" + i)
-                        .bookImage("bookImage" + i)
-                        .authors("저자" + i)
-                        .publisher("출판사" + i)
-                        .likeCount((long) i)
-                        .build())
-                .toList();
-    }
-
-    private List<Long> createLikeReviewIds() {
-        return IntStream.rangeClosed(1, 5)
-                .mapToLong(i -> i)
-                .boxed()
-                .collect(Collectors.toList());
-    }
-
-    private List<UserReadingStatusResponse> createReadingStatusResponse() {
-        return IntStream.range(0, 10)
-                .mapToObj(i -> UserReadingStatusResponse.builder()
-                        .isbn(String.valueOf(i))
-                        .bookTitle("책 제목" + i)
-                        .bookImage("책 표지" + i)
-                        .ratingAvg(i % 5.0 + 1)
-                        .build())
-                .toList();
-    }
-
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #128 

## 📝 작업 내용
- API Path 수정
    - `/v1/users/statuses` &rarr; `/v1/users/libraries/statuses`
- 유저 Controller에서 다른 도메인 API 분리
    - 유저 한줄평 페이지 조회
    - 유저 별점 페이지 조회
    - 유저 독서 상태 페이지 조회


## 💬 리뷰 요구 사항
🫡 